### PR TITLE
Langchain redis/release 0.0.4

### DIFF
--- a/libs/redis/docs/docker-compose.yml
+++ b/libs/redis/docs/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - ./:/home/jupyter/workspace/libs/redis/docs
     environment:
       - REDIS_URL=redis://redis:6379
-      - USER_AGENT=LangChainRedisJupyterNotebooks/0.0.3
+      - USER_AGENT=LangChainRedisJupyterNotebooks/0.0.4
     user: jupyter
     working_dir: /home/jupyter/workspace/libs/redis/docs
     depends_on:

--- a/libs/redis/docs/kitchensink.ipynb
+++ b/libs/redis/docs/kitchensink.ipynb
@@ -42,7 +42,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "langchain-redis version: langchain-redis_v0.0.3\n"
+      "langchain-redis version: langchain-redis_v0.0.4\n"
      ]
     }
    ],

--- a/libs/redis/langchain_redis/cache.py
+++ b/libs/redis/langchain_redis/cache.py
@@ -103,9 +103,9 @@ class RedisCache(BaseCache):
         redis_url: str = "redis://localhost:6379",
         ttl: Optional[int] = None,
         prefix: Optional[str] = "redis",
-        redis: Optional[Redis] = None,
+        redis_client: Optional[Redis] = None,
     ):
-        self.redis = redis or Redis.from_url(redis_url)
+        self.redis = redis_client or Redis.from_url(redis_url)
         try:
             self.redis.client_setinfo("LIB-NAME", __full_lib_name__)  # type: ignore
         except ResponseError:
@@ -330,9 +330,9 @@ class RedisSemanticCache(BaseCache):
         ttl: Optional[int] = None,
         name: Optional[str] = "llmcache",
         prefix: Optional[str] = "llmcache",
-        redis: Optional[Redis] = None,
+        redis_client: Optional[Redis] = None,
     ):
-        self.redis = redis or Redis.from_url(redis_url)
+        self.redis = redis_client or Redis.from_url(redis_url)
         self.embeddings = embeddings
         self.prefix = prefix
         vectorizer = EmbeddingsVectorizer(embeddings=self.embeddings)

--- a/libs/redis/langchain_redis/chat_message_history.py
+++ b/libs/redis/langchain_redis/chat_message_history.py
@@ -84,10 +84,10 @@ class RedisChatMessageHistory(BaseChatMessageHistory):
         key_prefix: str = "chat:",
         ttl: Optional[int] = None,
         index_name: str = "idx:chat_history",
-        redis: Optional[Redis] = None,
+        redis_client: Optional[Redis] = None,
         **kwargs: Any,
     ):
-        self.redis_client = redis or Redis.from_url(redis_url, **kwargs)
+        self.redis_client = redis_client or Redis.from_url(redis_url, **kwargs)
         try:
             self.redis_client.client_setinfo("LIB-NAME", __full_lib_name__)  # type: ignore
         except ResponseError:

--- a/libs/redis/langchain_redis/config.py
+++ b/libs/redis/langchain_redis/config.py
@@ -413,7 +413,7 @@ class RedisConfig(BaseModel):
 
                 config = RedisConfig.from_existing_index(
                     index_name="my_existing_index",
-                    redis=redis_client
+                    redis_client=redis_client
                 )
 
                 print(config.index_name)  # Output: my_existing_index

--- a/libs/redis/langchain_redis/version.py
+++ b/libs/redis/langchain_redis/version.py
@@ -1,5 +1,5 @@
 from redisvl.version import __version__ as __redisvl_version__  # type: ignore
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 __lib_name__ = f"langchain-redis_v{__version__}"
 __full_lib_name__ = f"redis-py(redisvl_v{__redisvl_version__};{__lib_name__})"

--- a/libs/redis/pyproject.toml
+++ b/libs/redis/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-redis"
-version = "0.0.3"
+version = "0.0.4"
 description = "An integration package connecting Redis and LangChain"
 authors = ["Brian Sam-Bodden <bsb@redis.com>"]
 readme = "README.md"

--- a/libs/redis/tests/integration_tests/test_cache.py
+++ b/libs/redis/tests/integration_tests/test_cache.py
@@ -186,7 +186,7 @@ class TestRedisCacheBasicIntegration:
 
 def test_redis_cache_with_preconfigured_client(redis_url: str) -> None:
     redis_client = Redis.from_url(redis_url)
-    cache = RedisCache(redis=redis_client)
+    cache = RedisCache(redis_client=redis_client)
 
     cache.update("test_prompt", "test_llm", [Generation(text="test_response")])
     result = cache.lookup("test_prompt", "test_llm")
@@ -204,7 +204,7 @@ def test_redis_semantic_cache_with_preconfigured_client(
     redis_client = Redis.from_url(redis_url)
     cache = RedisSemanticCache(
         embeddings=openai_embeddings,
-        redis=redis_client,
+        redis_client=redis_client,
     )
 
     prompt = "What is the capital of France?"

--- a/libs/redis/tests/integration_tests/test_chat_message_history.py
+++ b/libs/redis/tests/integration_tests/test_chat_message_history.py
@@ -252,3 +252,21 @@ def test_add_message_to_existing_session(redis_url: str) -> None:
 
     assert len(history1.messages) == 2
     assert len(history2.messages) == 2
+
+
+def test_chat_history_with_preconfigured_client(redis_url: str) -> None:
+    redis_client = Redis.from_url(redis_url)
+    session_id = f"test_session_{str(ULID())}"
+    history = RedisChatMessageHistory(session_id=session_id, redis_client=redis_client)
+
+    history.add_message(HumanMessage(content="Hello, AI!"))
+    history.add_message(AIMessage(content="Hello, human!"))
+
+    messages = history.messages
+    assert len(messages) == 2
+    assert isinstance(messages[0], HumanMessage)
+    assert isinstance(messages[1], AIMessage)
+    assert messages[0].content == "Hello, AI!"
+    assert messages[1].content == "Hello, human!"
+
+    history.clear()


### PR DESCRIPTION
* Changes param name for Redis PY client to `redis_client` consistently in all classes (it was `redis` in some classes)
* Adds extra tests for using classes with a Redis PY client
* Bumps the version to 0.0.4