### PR TITLE
fix: compare error message to create index

### DIFF
--- a/libs/redis/langchain_redis/chat_message_history.py
+++ b/libs/redis/langchain_redis/chat_message_history.py
@@ -107,7 +107,7 @@ class RedisChatMessageHistory(BaseChatMessageHistory):
         try:
             self.redis_client.ft(self.index_name).info()
         except ResponseError as e:
-            if str(e) == "Unknown index name":
+            if str(e).lower() == "unknown index name":
                 schema = (
                     TagField("$.session_id", as_name="session_id"),
                     TextField("$.data.content", as_name="content"),


### PR DESCRIPTION
I found out a problem in the error checking for index creation, I added a lowercase in the comparison to solve this problem.

![Screenshot from 2024-09-16 10-01-54](https://github.com/user-attachments/assets/8f4b63c3-3a4b-45e5-85c8-ac84da15e9f1)

