### PR TITLE
fix: with pydantic 2 validaton side-effects were not respected (index…

### DIFF
--- a/libs/redis/langchain_redis/config.py
+++ b/libs/redis/langchain_redis/config.py
@@ -93,6 +93,11 @@ class RedisConfig(BaseModel):
         arbitrary_types_allowed=True,
     )
 
+    def __init__(self, **data: Any):
+        super().__init__(**data)
+        if "schema" in data and self.index_schema is None:
+            self.index_schema = data["schema"]
+
     @model_validator(mode="before")
     @classmethod
     def check_schema_options(cls, values: Dict) -> Dict:


### PR DESCRIPTION
…_schema in Config)

Changes for Pydantic v2 broke some alias assignments - fix was to override the `__init__` to handle the alias explicitely.