### PR TITLE
 Fixed missing required positional argument: 'dtype' in buffer_to_array

### DIFF
--- a/libs/redis/langchain_redis/vectorstores.py
+++ b/libs/redis/langchain_redis/vectorstores.py
@@ -13,6 +13,7 @@ from redisvl.query import RangeQuery, VectorQuery  # type: ignore[import]
 from redisvl.query.filter import FilterExpression  # type: ignore[import]
 from redisvl.redis.utils import buffer_to_array, convert_bytes  # type: ignore[import]
 from redisvl.schema import StorageType  # type: ignore[import]
+from redisvl.schema.fields import VectorDataType
 
 from langchain_redis.config import RedisConfig
 from langchain_redis.version import __lib_name__
@@ -965,7 +966,7 @@ class RedisVectorStore(VectorStore):
                 doc_embeddings_dict = {
                     doc_id: doc[self.config.embedding_field]
                     if self.config.storage_type == StorageType.JSON.value
-                    else buffer_to_array(doc[self.config.embedding_field])
+                    else buffer_to_array(doc[self.config.embedding_field],dtype=VectorDataType.FLOAT32)
                     for doc_id, doc in zip(doc_ids, docs_from_storage)
                 }
 


### PR DESCRIPTION

issue: on the latest versions of redisvl, we need to pass the dtype in buffer_to_array calls. This PR addresses it. I haven't added the ability to use different data types (supported in redis) given we also use floatt32 along other code blogs on of vectorstore

```
buffer_to_array(doc[self.config.embedding_field])
TypeError: buffer_to_array() missing 1 required positional argument: 'dtype'
```
full traceback:

```
full traceback:
Traceback (most recent call last):
  File "/Users/fco/redislabs/opentelemetry-redis-llm-sample/rag.py", line 107, in <module>
    reply = chain.invoke("where did harrison work?")
  File "/Users/fco/Library/Caches/pypoetry/virtualenvs/opentelemetry-redis-llm-sample-BdtNUzVV-py3.9/lib/python3.9/site-packages/langchain_core/runnables/base.py", line 5354, in invoke
    return self.bound.invoke(
  File "/Users/fco/Library/Caches/pypoetry/virtualenvs/opentelemetry-redis-llm-sample-BdtNUzVV-py3.9/lib/python3.9/site-packages/langchain_core/runnables/base.py", line 3022, in invoke
    input = context.run(step.invoke, input, config, **kwargs)
  File "/Users/fco/Library/Caches/pypoetry/virtualenvs/opentelemetry-redis-llm-sample-BdtNUzVV-py3.9/lib/python3.9/site-packages/langchain_core/runnables/base.py", line 3727, in invoke
    output = {key: future.result() for key, future in zip(steps, futures)}
  File "/Users/fco/Library/Caches/pypoetry/virtualenvs/opentelemetry-redis-llm-sample-BdtNUzVV-py3.9/lib/python3.9/site-packages/langchain_core/runnables/base.py", line 3727, in <dictcomp>
    output = {key: future.result() for key, future in zip(steps, futures)}
  File "/opt/homebrew/Caskroom/miniforge/base/lib/python3.9/concurrent/futures/_base.py", line 440, in result
    return self.__get_result()
  File "/opt/homebrew/Caskroom/miniforge/base/lib/python3.9/concurrent/futures/_base.py", line 389, in __get_result
    raise self._exception
  File "/opt/homebrew/Caskroom/miniforge/base/lib/python3.9/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/fco/Library/Caches/pypoetry/virtualenvs/opentelemetry-redis-llm-sample-BdtNUzVV-py3.9/lib/python3.9/site-packages/langchain_core/runnables/base.py", line 3711, in _invoke_step
    return context.run(
  File "/Users/fco/Library/Caches/pypoetry/virtualenvs/opentelemetry-redis-llm-sample-BdtNUzVV-py3.9/lib/python3.9/site-packages/langchain_core/retrievers.py", line 254, in invoke
    raise e
  File "/Users/fco/Library/Caches/pypoetry/virtualenvs/opentelemetry-redis-llm-sample-BdtNUzVV-py3.9/lib/python3.9/site-packages/langchain_core/retrievers.py", line 247, in invoke
    result = self._get_relevant_documents(
  File "/Users/fco/Library/Caches/pypoetry/virtualenvs/opentelemetry-redis-llm-sample-BdtNUzVV-py3.9/lib/python3.9/site-packages/langchain_core/vectorstores/base.py", line 1089, in _get_relevant_documents
    docs = self.vectorstore.max_marginal_relevance_search(
  File "/Users/fco/Library/Caches/pypoetry/virtualenvs/opentelemetry-redis-llm-sample-BdtNUzVV-py3.9/lib/python3.9/site-packages/langchain_redis/vectorstores.py", line 1265, in max_marginal_relevance_search
    return self.max_marginal_relevance_search_by_vector(
  File "/Users/fco/Library/Caches/pypoetry/virtualenvs/opentelemetry-redis-llm-sample-BdtNUzVV-py3.9/lib/python3.9/site-packages/langchain_redis/vectorstores.py", line 1207, in max_marginal_relevance_search_by_vector
    docs_scores_embeddings = self.similarity_search_with_score_by_vector(
  File "/Users/fco/Library/Caches/pypoetry/virtualenvs/opentelemetry-redis-llm-sample-BdtNUzVV-py3.9/lib/python3.9/site-packages/langchain_redis/vectorstores.py", line 965, in similarity_search_with_score_by_vector
    doc_embeddings_dict = {
  File "/Users/fco/Library/Caches/pypoetry/virtualenvs/opentelemetry-redis-llm-sample-BdtNUzVV-py3.9/lib/python3.9/site-packages/langchain_redis/vectorstores.py", line 968, in <dictcomp>
    else buffer_to_array(doc[self.config.embedding_field])
TypeError: buffer_to_array() missing 1 required positional argument: 'dtype'
```