### PR TITLE
Support get_by_ids

### DIFF
--- a/libs/redis/tests/integration_tests/test_vectorstores_hash.py
+++ b/libs/redis/tests/integration_tests/test_vectorstores_hash.py
@@ -573,6 +573,38 @@ def test_similarity_search_with_scores(redis_url: str) -> None:
     vector_store.index.delete(drop=True)
 
 
+def test_get_by_ids(redis_url: str) -> None:
+    """Test end to end construction and getting by ids."""
+    # Create embeddings
+    embeddings = OpenAIEmbeddings()
+
+    # Create a unique index name for testing
+    index_name = f"test_index_{str(ULID())}"
+
+    doc_1_id = "doc-1"
+    doc_1_content = "foo"
+    documents = [
+        Document(page_content=doc_1_content, id=doc_1_id),
+    ]
+
+    vector_store = RedisVectorStore(
+        embeddings=embeddings,
+        index_name=index_name,
+        key_prefix="tst12",
+        redis_url=redis_url,
+    )
+    vector_store.add_documents(documents, keys=[doc.id for doc in documents])
+
+    # Perform similarity search
+    docs = vector_store.get_by_ids([doc_1_id])
+    assert docs == [
+        Document(page_content=doc_1_content, id=doc_1_id),
+    ]
+
+    # Clean up
+    vector_store.index.delete(drop=True)
+
+
 def test_add_texts(redis_url: str) -> None:
     """Test adding texts to an existing index."""
     embeddings = OpenAIEmbeddings()

--- a/libs/redis/tests/integration_tests/test_vectorstores_json.py
+++ b/libs/redis/tests/integration_tests/test_vectorstores_json.py
@@ -585,6 +585,40 @@ def test_similarity_search_with_scores(redis_url: str) -> None:
     vector_store.index.delete(drop=True)
 
 
+# TODO: Parameterize for json + hash
+def test_get_by_ids(redis_url: str) -> None:
+    """Test end to end construction and getting by ids."""
+    # Create embeddings
+    embeddings = OpenAIEmbeddings()
+
+    # Create a unique index name for testing
+    index_name = f"test_index_{str(ULID())}"
+
+    doc_1_id = "doc-1"
+    doc_1_content = "foo"
+    documents = [
+        Document(page_content=doc_1_content, id=doc_1_id),
+    ]
+
+    vector_store = RedisVectorStore(
+        embeddings=embeddings,
+        index_name=index_name,
+        key_prefix="tst12",
+        redis_url=redis_url,
+        # storage_type="json",
+    )
+    vector_store.add_documents(documents, keys=[doc.id for doc in documents])
+
+    # Perform similarity search
+    docs = vector_store.get_by_ids([doc_1_id])
+    assert docs == [
+        Document(page_content=doc_1_content, id=doc_1_id),
+    ]
+
+    # Clean up
+    vector_store.index.delete(drop=True)
+
+
 def test_add_texts(redis_url: str) -> None:
     """Test adding texts to an existing index."""
     embeddings = OpenAIEmbeddings()

--- a/libs/redis/tests/integration_tests/test_vectorstores_json.py
+++ b/libs/redis/tests/integration_tests/test_vectorstores_json.py
@@ -585,7 +585,6 @@ def test_similarity_search_with_scores(redis_url: str) -> None:
     vector_store.index.delete(drop=True)
 
 
-# TODO: Parameterize for json + hash
 def test_get_by_ids(redis_url: str) -> None:
     """Test end to end construction and getting by ids."""
     # Create embeddings
@@ -605,7 +604,7 @@ def test_get_by_ids(redis_url: str) -> None:
         index_name=index_name,
         key_prefix="tst12",
         redis_url=redis_url,
-        # storage_type="json",
+        storage_type="json",
     )
     vector_store.add_documents(documents, keys=[doc.id for doc in documents])
 

--- a/libs/redis/tests/unit_tests/test_vectorstores.py
+++ b/libs/redis/tests/unit_tests/test_vectorstores.py
@@ -170,6 +170,19 @@ class TestRedisVectorStore:
         assert len(results) == 2
         assert all(isinstance(doc, Document) for doc in results)
 
+    def test_get_by_ids(self, vector_store: RedisVectorStore) -> None:
+        doc_1_id = "doc-1"
+        doc_1_content = "Hello, world!"
+        docs = [
+            Document(page_content=doc_1_content, id=doc_1_id),
+            Document(page_content="Test document", id="doc-2"),
+        ]
+        vector_store.add_documents(docs)
+        results = vector_store.get_by_ids([doc_1_id])
+        assert len(results) == 1
+        assert isinstance(results[0], Document)
+        assert results[0].page_content == doc_1_content
+
     def test_delete(self, vector_store: RedisVectorStore) -> None:
         keys = vector_store.add_texts(["Hello, world!", "Test document"])
         result = vector_store.delete(keys)

--- a/libs/redis/tests/unit_tests/test_vectorstores.py
+++ b/libs/redis/tests/unit_tests/test_vectorstores.py
@@ -170,19 +170,6 @@ class TestRedisVectorStore:
         assert len(results) == 2
         assert all(isinstance(doc, Document) for doc in results)
 
-    def test_get_by_ids(self, vector_store: RedisVectorStore) -> None:
-        doc_1_id = "doc-1"
-        doc_1_content = "Hello, world!"
-        docs = [
-            Document(page_content=doc_1_content, id=doc_1_id),
-            Document(page_content="Test document", id="doc-2"),
-        ]
-        vector_store.add_documents(docs)
-        results = vector_store.get_by_ids([doc_1_id])
-        assert len(results) == 1
-        assert isinstance(results[0], Document)
-        assert results[0].page_content == doc_1_content
-
     def test_delete(self, vector_store: RedisVectorStore) -> None:
         keys = vector_store.add_texts(["Hello, world!", "Test document"])
         result = vector_store.delete(keys)


### PR DESCRIPTION
Closes #41 

- Implements the `get_by_ids` method, using `JSON.MGET` for JSON storage and pipeline + `HGETALL` for hash storage.
- The doc on the method is copied straight from the langchain base class
- Adds integration tests for JSON and hash data types
- I tried to add a unit test, but seems like I would have to mock a lot of the Redis library to make it work right. I ultimately removed it in the last commit. Let me know if this is a blocker. Maybe we could consider some kind of intermediate layer in between the vector store and Redis to make mocking easier. 