### PR TITLE
fix: index response error compatible with stack and redis 8

### DIFF
--- a/libs/redis/langchain_redis/chat_message_history.py
+++ b/libs/redis/langchain_redis/chat_message_history.py
@@ -107,7 +107,8 @@ class RedisChatMessageHistory(BaseChatMessageHistory):
         try:
             self.redis_client.ft(self.index_name).info()
         except ResponseError as e:
-            if str(e).lower() == "unknown index name":
+            msg = str(e).lower()
+            if "unknown index name" in msg or "no such index" in msg:
                 schema = (
                     TagField("$.session_id", as_name="session_id"),
                     TextField("$.data.content", as_name="content"),


### PR DESCRIPTION
It appears `redis8-M03` throws "no such index" when an index is not found where `redis-stack` throws "Unknown index name". This covers both cases.