### PR TITLE
fix: handle empty values in get_by_ids for RedisVectorStore

### DIFF
--- a/libs/redis/langchain_redis/vectorstores.py
+++ b/libs/redis/langchain_redis/vectorstores.py
@@ -1339,7 +1339,7 @@ class RedisVectorStore(VectorStore):
             values = pipe.execute()
         documents = []
         for id_, value in zip(ids, values):
-            if value is None:
+            if value is None or not value:
                 continue
             if self.config.storage_type == StorageType.JSON.value:
                 doc = cast(dict, value)


### PR DESCRIPTION
# Why
- In `get_by_ids` function when you get the ids and the id is not present results in an error
```py
  File "/usr/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/**/backend/venv/lib/python3.11/site-packages/langchain_core/runnables/config.py", line 613, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/**/backend/venv/lib/python3.11/site-packages/langchain_redis/vectorstores.py", line 1353, in get_by_ids
    page_content=doc[self.config.content_field],
                 ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'text'
```
This is because

`values = redis.json().mget(full_ids, ".")` returns an empty dictionary `{}` instead of `none` 


Proof: if I do `print(id_,value, value is None, value == {}, len(value)==0, not value)` 
![image](https://github.com/user-attachments/assets/1b6aa973-1139-4c23-8596-cbd4bc0ac441)
We get `bb6ef013-9abd-5b9e-bf48-5db4cf05b9ef {} False True True True`

- The fix is simple: just add an empty dictionary check it works well
```py
            if value is None or not value:
                continue
```