### PR TITLE
fix: update RedisVL semantic cache import to fix deprecation warning

### DIFF
--- a/libs/redis/langchain_redis/cache.py
+++ b/libs/redis/langchain_redis/cache.py
@@ -16,7 +16,7 @@ from pydantic import ConfigDict, Field
 from redis import Redis
 from redis.commands.json.path import Path
 from redis.exceptions import ResponseError
-from redisvl.extensions.llmcache import (  # type: ignore[import]
+from redisvl.extensions.cache.llm import (  # type: ignore[import]
     SemanticCache as RedisVLSemanticCache,
 )
 from redisvl.schema.fields import VectorDataType  # type: ignore[import]


### PR DESCRIPTION
Updated import from 'redisvl.extensions.llmcache' to 'redisvl.extensions.cache.llm' to address deprecation warning. Adjusted mock implementation in unit tests to ensure compatibility with new module.