### PR TITLE
fix: Fix session id bug by using the token escaper class, use redisvl for querying, and use ULIDs instead of timestamps to avoid collisions

### DIFF
--- a/libs/redis/langchain_redis/chat_message_history.py
+++ b/libs/redis/langchain_redis/chat_message_history.py
@@ -1,4 +1,4 @@
-import json  # noqa: I001
+import json
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -6,11 +6,10 @@ from langchain_core.chat_history import BaseChatMessageHistory
 from langchain_core.messages import BaseMessage, messages_from_dict
 from redis import Redis
 from redis.exceptions import ResponseError
-from redis.commands.json.path import Path
-from redis.commands.search.field import NumericField, TagField, TextField
-from redis.commands.search.indexDefinition import IndexDefinition, IndexType
-from redis.commands.search.query import Query
-from redisvl.utils.token_escaper import TokenEscaper  # type: ignore[import-untyped]
+from redisvl.index import SearchIndex  # type: ignore
+from redisvl.query import CountQuery, FilterQuery, TextQuery  # type: ignore
+from redisvl.query.filter import Tag  # type: ignore
+from ulid import ULID
 
 from langchain_redis.version import __full_lib_name__
 
@@ -38,11 +37,10 @@ def _noop_push_handler(response: Any) -> None:
 
 
 class RedisChatMessageHistory(BaseChatMessageHistory):
-    """Redis-based implementation of chat message history.
+    """Redis-based implementation of chat message history using RedisVL.
 
-    This class provides a way to store and retrieve chat message history using Redis.
-    It implements the BaseChatMessageHistory interface and uses Redis JSON capabilities
-    for efficient storage and retrieval of messages.
+    This class provides a way to store and retrieve chat message history using Redis
+    with RedisVL for efficient indexing, querying, and document management.
 
     Attributes:
         redis_client (Redis): The Redis client instance.
@@ -56,11 +54,11 @@ class RedisChatMessageHistory(BaseChatMessageHistory):
         redis_url (str, optional): URL of the Redis instance. Defaults to "redis://localhost:6379".
         key_prefix (str, optional): Prefix for Redis keys. Defaults to "chat:".
         ttl (Optional[int], optional): Time-to-live for entries in seconds.
-                                       Defaults to None (no expiration).
+            Defaults to None (no expiration).
         index_name (str, optional): Name of the Redis search index.
-                                    Defaults to "idx:chat_history".
-        redis (Optional[Redis], optional): Existing Redis client instance. If provided,
-                                           redis_url is ignored.
+            Defaults to "idx:chat_history".
+        redis_client (Optional[Redis], optional): Existing Redis client instance.
+            If provided, redis_url is ignored.
         **kwargs: Additional keyword arguments to pass to the Redis client.
 
     Example:
@@ -72,7 +70,7 @@ class RedisChatMessageHistory(BaseChatMessageHistory):
             history = RedisChatMessageHistory(
                 session_id="user123",
                 redis_url="redis://localhost:6379",
-                ttl=3600  # Messages expire after 1 hour
+                ttl=3600  # Expire chat history after 1 hour
             )
 
             # Add messages to the history
@@ -86,20 +84,19 @@ class RedisChatMessageHistory(BaseChatMessageHistory):
             for message in messages:
                 print(f"{message.type}: {message.content}")
 
-            # Clear the history
+            # Clear the history for the session
             history.clear()
 
     Note:
-        - This class uses Redis JSON for storing messages, allowing for efficient
-          querying and retrieval.
-        - A Redis search index is created to enable fast lookups and potential future
-          search needs over the chat history.
+        - This class uses RedisVL for managing Redis JSON storage and search indexes,
+          providing efficient querying and retrieval.
+        - A Redis search index is created to enable fast lookups and search
+          capabilities over the chat history.
         - If TTL is set, message entries will automatically expire after the
           specified duration.
         - The session_id is used to group messages belonging to the same conversation
           or user session.
-        - Session IDs containing special characters (such as hyphens in UUIDs) are
-          automatically escaped for Redis search queries to prevent syntax errors.
+        - RedisVL automatically handles tokenization and escaping for search queries.
     """
 
     def __init__(
@@ -112,7 +109,6 @@ class RedisChatMessageHistory(BaseChatMessageHistory):
         redis_client: Optional[Redis] = None,
         **kwargs: Any,
     ):
-        # TODO -- switch over to use RedisVL for this all
         self.redis_client = redis_client or Redis.from_url(redis_url, **kwargs)
 
         # Configure Redis client to use a no-op push handler when PubSub is initialized
@@ -124,73 +120,71 @@ class RedisChatMessageHistory(BaseChatMessageHistory):
         except ResponseError:
             # Fall back to a simple log echo
             self.redis_client.echo(__full_lib_name__)
+
+        if session_id in ("", None):
+            raise ValueError("session_id must be a non-empty, valid string")
+
         self.session_id = session_id
         self.key_prefix = key_prefix
         self.ttl = ttl
         self.index_name = index_name
-        self._token_escaper = TokenEscaper()
-        self._ensure_index()
+
+        # Create RedisVL SearchIndex
+        self._create_search_index()
+
+    def _create_search_index(self) -> None:
+        """Create and configure the RedisVL SearchIndex."""
+        schema = {
+            "index": {
+                "name": self.index_name,
+                "prefix": self.key_prefix,
+                "storage_type": "json",
+            },
+            "fields": [
+                {"name": "session_id", "type": "tag", "path": "$.session_id"},
+                {"name": "content", "type": "text", "path": "$.data.content"},
+                {"name": "type", "type": "tag", "path": "$.type"},
+                {"name": "timestamp", "type": "numeric", "path": "$.timestamp"},
+            ],
+        }
+
+        self.index = SearchIndex.from_dict(schema, redis_client=self.redis_client)
+        self.index.create(overwrite=False)
 
     @property
     def id(self) -> str:
         return self.session_id
 
-    def _escape_session_id(self) -> str:
-        r"""Escape the session ID for use in Redis search queries.
-
-        This method uses RedisVL's TokenEscaper to properly escape special characters
-        in the session ID that could be interpreted as operators in Redis search syntax.
-        For example, hyphens (-) are escaped as \- to prevent them from being
-        interpreted as NOT operators.
-
-        Returns:
-            str: The escaped session ID safe for use in Redis search queries.
-        """
-        return self._token_escaper.escape(self.session_id)
-
-    def _ensure_index(self) -> None:
-        try:
-            self.redis_client.ft(self.index_name).info()
-        except ResponseError as e:
-            msg = str(e).lower()
-            if "unknown index name" in msg or "no such index" in msg:
-                schema = (
-                    TagField("$.session_id", as_name="session_id"),
-                    TextField("$.data.content", as_name="content"),
-                    TagField("$.type", as_name="type"),
-                    NumericField("$.timestamp", as_name="timestamp"),
-                )
-                definition = IndexDefinition(
-                    prefix=[self.key_prefix], index_type=IndexType.JSON
-                )
-                self.redis_client.ft(self.index_name).create_index(
-                    schema, definition=definition
-                )
-            else:
-                raise
-
     @property
     def messages(self) -> List[BaseMessage]:  # type: ignore
-        query = (
-            Query(f"@session_id:{{{self._escape_session_id()}}}")
-            .sort_by("timestamp", asc=True)
-            .paging(0, 10000)
-        )
-        results = self.redis_client.ft(self.index_name).search(query)
+        """Retrieve all messages for the current session, sorted by timestamp."""
+        messages_query = FilterQuery(
+            filter_expression=Tag("session_id") == self.session_id,
+            return_fields=["type", "$.data"],
+            num_results=10000,
+        ).sort_by("timestamp", asc=True)
+
+        messages = self.index.query(messages_query)
+
+        # Unpack message results and load from dict
         return messages_from_dict(
             [
-                {
-                    "type": json.loads(doc.json)["type"],
-                    "data": json.loads(doc.json)["data"],
-                }
-                for doc in results.docs
+                {"type": msg["type"], "data": json.loads(msg["$.data"])}
+                for msg in messages
             ]
         )
 
-    def add_message(self, message: BaseMessage) -> None:
-        """Add a message to the chat history.
+    def _message_key(self, message_id: Optional[str] = None) -> str:
+        """Construct message key based on key prefix, session, and unique message ID."""
+        if message_id is None:
+            message_id = str(ULID())
+        return f"{self.key_prefix}{self.session_id}:{message_id}"
 
-        This method adds a new message to the Redis store for the current session.
+    def add_message(self, message: BaseMessage) -> None:
+        """Add a message to the chat history using RedisVL.
+
+        This method adds a new message to the Redis store for the current session
+        using RedisVL's document loading capabilities.
 
         Args:
             message (BaseMessage): The message to add to the history. This should be an
@@ -226,8 +220,8 @@ class RedisChatMessageHistory(BaseChatMessageHistory):
         Note:
             - Each message is stored as a separate entry in Redis, associated
               with the current session_id.
-            - Messages are stored using Redis JSON capabilities for efficient storage
-              and retrieval.
+            - Messages are stored using RedisVL's JSON capabilities for efficient
+              storage and retrieval.
             - If a TTL (Time To Live) was specified when initializing the history,
               it will be applied to each message.
             - The message's content, type, and any additional data (like timestamp)
@@ -239,28 +233,30 @@ class RedisChatMessageHistory(BaseChatMessageHistory):
               Consider implementing size limits if dealing with potentially
               large messages.
         """
-        data_to_store = {
+        timestamp = datetime.now().timestamp()
+        message_id = str(ULID())
+        redis_msg = {
             "type": message.type,
+            "message_id": message_id,
             "data": {
                 "content": message.content,
                 "additional_kwargs": message.additional_kwargs,
                 "type": message.type,
             },
             "session_id": self.session_id,
-            "timestamp": datetime.now().timestamp(),
+            "timestamp": timestamp,
         }
 
-        key = f"{self.key_prefix}{self.session_id}:{data_to_store['timestamp']}"
-        self.redis_client.json().set(key, Path.root_path(), data_to_store)
-
-        if self.ttl:
-            self.redis_client.expire(key, self.ttl)
+        # Use RedisVL to load the data
+        self.index.load(
+            data=[redis_msg], keys=[self._message_key(message_id)], ttl=self.ttl
+        )
 
     def clear(self) -> None:
         """Clear all messages from the chat history for the current session.
 
         This method removes all messages associated with the current session_id from
-        the Redis store.
+        the Redis store using RedisVL queries.
 
         Returns:
             None
@@ -285,24 +281,43 @@ class RedisChatMessageHistory(BaseChatMessageHistory):
 
         Note:
             - This method only clears messages for the current session_id.
-            - It uses a Redis search query to find all relevant messages and then
-              deletes them.
-            - The operation is atomic - either all messages are deleted, or none are.
+            - It uses RedisVL's FilterQuery to find all relevant messages and then
+              deletes them individually using the Redis client.
+            - The operation removes all messages for the current session only.
             - After clearing, the Redis search index is still maintained, allowing
               for immediate use of the same session_id for new messages if needed.
             - This operation is irreversible. Make sure you want to remove all messages
               before calling this method.
         """
-        query = Query(f"@session_id:{{{self._escape_session_id()}}}").paging(0, 10000)
-        results = self.redis_client.ft(self.index_name).search(query)
-        for doc in results.docs:
-            self.redis_client.delete(doc.id)
+        # Get total count of records to delete
+        session_filter = Tag("session_id") == self.session_id
+        count_query = CountQuery(filter_expression=session_filter)
+        total_count = self.index.query(count_query)
+
+        if total_count > 0:
+            # Collect all keys first to avoid pagination issues during deletion
+            all_keys = []
+            filter_query = FilterQuery(
+                filter_expression=session_filter, num_results=total_count
+            )
+
+            # Use pagination to collect all keys without deleting during iteration
+            for results in self.index.paginate(filter_query, page_size=50):
+                all_keys.extend([res["id"] for res in results])
+
+            # Now delete all keys at once
+            if all_keys:
+                self.index.drop_keys(all_keys)
+
+    def delete(self) -> None:
+        """Delete all sessions and the chat history index from Redis."""
+        self.index.delete(drop=True)
 
     def search_messages(self, query: str, limit: int = 10) -> List[Dict[str, Any]]:
         """Search for messages in the chat history that match the given query.
 
         This method performs a full-text search on the content of messages in the
-        current session.
+        current session using RedisVL's TextQuery capabilities.
 
         Args:
             query (str): The search query string to match against message content.
@@ -347,8 +362,8 @@ class RedisChatMessageHistory(BaseChatMessageHistory):
                     print("---")
 
         Note:
-            - The search is performed using the Redis search capabilities, which allows
-              for efficient full-text search.
+            - The search is performed using RedisVL's TextQuery capabilities, which
+              allows for efficient full-text search.
             - The search is case-insensitive and uses Redis' default tokenization
               and stemming.
             - Only messages from the current session (as defined by session_id)
@@ -359,15 +374,28 @@ class RedisChatMessageHistory(BaseChatMessageHistory):
             - This method is useful for quickly finding relevant parts of a
               conversation without having to iterate through all messages.
         """
-        search_query = (
-            Query(f"(@session_id:{{{self._escape_session_id()}}}) (@content:{query})")
-            .sort_by("timestamp", asc=True)
-            .paging(0, limit)
-        )
-        results = self.redis_client.ft(self.index_name).search(search_query)
+        if query in ("", None):
+            return []
 
-        return [json.loads(doc.json)["data"] for doc in results.docs]
+        text_query = TextQuery(
+            text=query,
+            text_field_name="content",
+            filter_expression=Tag("session_id") == self.session_id,
+            return_fields=["type", "$.data"],
+            num_results=limit,
+            stopwords=None,  # Disable stopwords to avoid NLTK dependency
+        )
+
+        messages = self.index.query(text_query)
+
+        search_data = []
+        for msg in messages:
+            search_data.append(json.loads(msg["$.data"]))
+
+        return search_data
 
     def __len__(self) -> int:
-        query = Query(f"@session_id:{{{self._escape_session_id()}}}").no_content()
-        return self.redis_client.ft(self.index_name).search(query).total
+        """Return the number of messages in the chat history for the current session."""
+        return self.index.query(
+            CountQuery(filter_expression=Tag("session_id") == self.session_id)
+        )

--- a/libs/redis/tests/integration_tests/test_chat_message_history.py
+++ b/libs/redis/tests/integration_tests/test_chat_message_history.py
@@ -24,7 +24,7 @@ def chat_history(redis_url: str) -> Generator[RedisChatMessageHistory, None, Non
     try:
         yield history
     finally:
-        history.clear()
+        history.delete()
 
 
 def test_add_and_retrieve_messages(chat_history: RedisChatMessageHistory) -> None:
@@ -306,3 +306,567 @@ def test_session_id_with_special_characters(redis_url: str) -> None:
     finally:
         # Ensure cleanup even if test fails
         history.clear()
+
+
+def test_timestamp_sorting(chat_history: RedisChatMessageHistory) -> None:
+    """Test that messages are returned in correct timestamp order."""
+    # Add messages with small delays to ensure different timestamps
+    chat_history.add_message(HumanMessage(content="First message"))
+    chat_history.add_message(AIMessage(content="Second message"))
+    chat_history.add_message(HumanMessage(content="Third message"))
+    chat_history.add_message(AIMessage(content="Fourth message"))
+
+    # Retrieve messages and verify they're in chronological order
+    messages = chat_history.messages
+    assert len(messages) == 4
+
+    # Check content order
+    assert messages[0].content == "First message"
+    assert messages[1].content == "Second message"
+    assert messages[2].content == "Third message"
+    assert messages[3].content == "Fourth message"
+
+    # Check message types
+    assert isinstance(messages[0], HumanMessage)
+    assert isinstance(messages[1], AIMessage)
+    assert isinstance(messages[2], HumanMessage)
+    assert isinstance(messages[3], AIMessage)
+
+
+def test_session_sensitive_clear(redis_url: str) -> None:
+    """Test that clear() only clears messages for the current session."""
+    session1_id = f"session1_{str(ULID())}"
+    session2_id = f"session2_{str(ULID())}"
+
+    history1 = RedisChatMessageHistory(session_id=session1_id, redis_url=redis_url)
+    history2 = RedisChatMessageHistory(session_id=session2_id, redis_url=redis_url)
+
+    try:
+        # Add messages to both sessions
+        history1.add_message(HumanMessage(content="Session 1 message 1"))
+        history1.add_message(AIMessage(content="Session 1 message 2"))
+
+        history2.add_message(HumanMessage(content="Session 2 message 1"))
+        history2.add_message(AIMessage(content="Session 2 message 2"))
+
+        # Verify both sessions have messages
+        assert len(history1.messages) == 2
+        assert len(history2.messages) == 2
+
+        # Clear only session 1
+        history1.clear()
+
+        # Verify session 1 is empty but session 2 still has messages
+        assert len(history1.messages) == 0
+        assert len(history2.messages) == 2
+
+        # Verify session 2 messages are intact
+        session2_messages = history2.messages
+        assert session2_messages[0].content == "Session 2 message 1"
+        assert session2_messages[1].content == "Session 2 message 2"
+
+    finally:
+        # Clean up both sessions
+        history1.clear()
+        history2.clear()
+
+
+def test_empty_session_id(redis_url: str) -> None:
+    """Test behavior with empty session ID."""
+    with pytest.raises(ValueError):
+        RedisChatMessageHistory(session_id="", redis_url=redis_url)
+
+
+def test_none_session_id(redis_url: str) -> None:
+    """Test behavior with None session ID."""
+    with pytest.raises(ValueError):
+        RedisChatMessageHistory(session_id=None, redis_url=redis_url)  # type: ignore
+
+
+def test_unicode_session_id(redis_url: str) -> None:
+    """Test behavior with Unicode characters in session ID."""
+    unicode_session_id = f"session_测试_🚀_{str(ULID())}"
+    history = RedisChatMessageHistory(
+        session_id=unicode_session_id, redis_url=redis_url
+    )
+
+    try:
+        history.add_message(HumanMessage(content="Unicode session test"))
+        messages = history.messages
+        assert len(messages) == 1
+        assert messages[0].content == "Unicode session test"
+    finally:
+        history.delete()
+
+
+def test_empty_message_content(chat_history: RedisChatMessageHistory) -> None:
+    """Test adding messages with empty content."""
+    history = chat_history
+
+    # Test empty string content
+    history.add_message(HumanMessage(content=""))
+    history.add_message(AIMessage(content=""))
+
+    messages = history.messages
+    assert len(messages) == 2
+    assert messages[0].content == ""
+    assert messages[1].content == ""
+
+
+def test_very_large_message_content(chat_history: RedisChatMessageHistory) -> None:
+    """Test adding messages with very large content."""
+    large_content = "x" * 100000  # 100KB message
+    chat_history.add_message(HumanMessage(content=large_content))
+
+    messages = chat_history.messages
+    assert len(messages) == 1
+    assert messages[0].content == large_content
+
+
+def test_unicode_message_content(chat_history: RedisChatMessageHistory) -> None:
+    """Test messages with Unicode content including emojis."""
+    unicode_content = "Hello 世界! 🌍🚀 Testing Unicode: αβγδε ñáéíóú"
+    chat_history.add_message(HumanMessage(content=unicode_content))
+
+    messages = chat_history.messages
+    assert len(messages) == 1
+    assert messages[0].content == unicode_content
+
+
+def test_special_characters_in_content(chat_history: RedisChatMessageHistory) -> None:
+    """Test messages with special characters that might break JSON or search."""
+    special_content = 'Test with "quotes", {brackets}, [arrays], and \\ backslashes'
+    chat_history.add_message(HumanMessage(content=special_content))
+    messages = chat_history.messages
+    assert len(messages) == 1
+    assert messages[0].content == special_content
+
+
+def test_message_with_additional_kwargs(chat_history: RedisChatMessageHistory) -> None:
+    """Test messages with additional_kwargs are preserved."""
+    message = HumanMessage(
+        content="Test message",
+        additional_kwargs={"custom_field": "custom_value", "number": 42},
+    )
+    chat_history.add_message(message)
+
+    messages = chat_history.messages
+    assert len(messages) == 1
+    assert messages[0].content == "Test message"
+    assert messages[0].additional_kwargs == {
+        "custom_field": "custom_value",
+        "number": 42,
+    }
+
+
+def test_search_case_insensitive(chat_history: RedisChatMessageHistory) -> None:
+    """Test that search is case insensitive."""
+    chat_history.add_message(HumanMessage(content="Hello World"))
+    chat_history.add_message(HumanMessage(content="GOODBYE WORLD"))
+
+    # Test different cases
+    results = chat_history.search_messages("hello")
+    assert len(results) == 1
+
+    results = chat_history.search_messages("HELLO")
+    assert len(results) == 1
+
+    results = chat_history.search_messages("world")
+    assert len(results) == 2
+
+    results = chat_history.search_messages("WORLD")
+    assert len(results) == 2
+
+
+def test_search_with_limit_zero(chat_history: RedisChatMessageHistory) -> None:
+    """Test search with limit=0."""
+    chat_history.add_message(HumanMessage(content="Test message"))
+
+    results = chat_history.search_messages("test", limit=0)
+    assert len(results) == 0
+
+
+def test_search_with_large_limit(chat_history: RedisChatMessageHistory) -> None:
+    """Test search with very large limit."""
+    for i in range(5):
+        chat_history.add_message(HumanMessage(content=f"Test message {i}"))
+
+    results = chat_history.search_messages("test", limit=1000)
+    assert len(results) == 5
+
+
+def test_invalid_redis_url() -> None:
+    """Test behavior with invalid Redis URL."""
+    with pytest.raises(Exception):  # Could be ConnectionError or similar
+        history = RedisChatMessageHistory(
+            session_id="test", redis_url="redis://invalid-host:6379"
+        )
+        # Try to use it to trigger connection
+        history.add_message(HumanMessage(content="Test"))
+
+
+def test_custom_key_prefix(redis_url: str) -> None:
+    """Test custom key prefix functionality."""
+    custom_prefix = "custom_chat:"
+    session_id = f"test_{str(ULID())}"
+
+    history = RedisChatMessageHistory(
+        session_id=session_id, redis_url=redis_url, key_prefix=custom_prefix
+    )
+
+    try:
+        history.add_message(HumanMessage(content="Test with custom prefix"))
+        messages = history.messages
+        assert len(messages) == 1
+        assert messages[0].content == "Test with custom prefix"
+    finally:
+        history.delete()
+
+
+def test_custom_index_name(redis_url: str) -> None:
+    """Test custom index name functionality."""
+    custom_index = "custom_chat_index"
+    session_id = f"test_{str(ULID())}"
+
+    history = RedisChatMessageHistory(
+        session_id=session_id, redis_url=redis_url, index_name=custom_index
+    )
+
+    try:
+        history.add_message(HumanMessage(content="Test with custom index"))
+        messages = history.messages
+        assert len(messages) == 1
+        assert messages[0].content == "Test with custom index"
+
+        # Verify the custom index was created
+        redis_client = Redis.from_url(redis_url)
+        index_info = redis_client.ft(custom_index).info()
+        assert index_info["index_name"] == custom_index
+    finally:
+        history.delete()
+
+
+def test_clear_empty_session(chat_history: RedisChatMessageHistory) -> None:
+    """Test clearing an empty session doesn't cause errors."""
+    # Should not raise any exceptions
+    chat_history.clear()
+    assert len(chat_history.messages) == 0
+
+
+def test_clear_large_session(redis_url: str) -> None:
+    """Test clearing a session with many messages."""
+    session_id = f"large_clear_test_{str(ULID())}"
+    history = RedisChatMessageHistory(session_id=session_id, redis_url=redis_url)
+
+    try:
+        # Add many messages
+        for i in range(100):
+            history.add_message(HumanMessage(content=f"Message {i}"))
+
+        assert len(history.messages) == 100
+
+        # Clear all messages
+        history.clear()
+        assert len(history.messages) == 0
+    finally:
+        history.delete()
+
+
+def test_message_ordering_with_rapid_additions(redis_url: str) -> None:
+    """Test message ordering when messages are added very rapidly."""
+    session_id = f"rapid_test_{str(ULID())}"
+    history = RedisChatMessageHistory(session_id=session_id, redis_url=redis_url)
+
+    try:
+        # Add messages very rapidly
+        for i in range(20):
+            history.add_message(HumanMessage(content=f"Rapid message {i}"))
+
+        messages = history.messages
+        assert len(messages) == 20
+
+        # Verify ordering (should be chronological)
+        for i, message in enumerate(messages):
+            assert message.content == f"Rapid message {i}"
+    finally:
+        history.delete()
+
+
+def test_ttl_edge_cases(redis_url: str) -> None:
+    """Test TTL edge cases."""
+    session_id = f"ttl_edge_test_{str(ULID())}"
+
+    # Test TTL = 0 (should expire immediately)
+    history_zero = RedisChatMessageHistory(
+        session_id=f"{session_id}_zero", redis_url=redis_url, ttl=0
+    )
+
+    try:
+        history_zero.add_message(HumanMessage(content="Should expire immediately"))
+        # Message might already be expired
+        time.sleep(0.1)
+        messages = history_zero.messages
+        # Could be 0 or 1 depending on timing
+        assert len(messages) <= 1
+    finally:
+        history_zero.clear()
+
+    # Test very large TTL
+    history_large = RedisChatMessageHistory(
+        session_id=f"{session_id}_large",
+        redis_url=redis_url,
+        ttl=2147483647,  # Max 32-bit int
+    )
+
+    try:
+        history_large.add_message(HumanMessage(content="Long TTL message"))
+        messages = history_large.messages
+        assert len(messages) == 1
+    finally:
+        history_large.clear()
+
+
+def test_id_property(chat_history: RedisChatMessageHistory) -> None:
+    """Test the id property returns session_id."""
+    assert chat_history.id == chat_history.session_id
+
+
+def test_messages_property_empty(chat_history: RedisChatMessageHistory) -> None:
+    """Test messages property when no messages exist."""
+    messages = chat_history.messages
+    assert isinstance(messages, list)
+    assert len(messages) == 0
+
+
+def test_len_with_cleared_session(chat_history: RedisChatMessageHistory) -> None:
+    """Test __len__ after clearing session."""
+    chat_history.add_message(HumanMessage(content="Test"))
+    assert len(chat_history) == 1
+
+    chat_history.clear()
+    assert len(chat_history) == 0
+
+
+def test_index_recreation_after_deletion(redis_url: str) -> None:
+    """Test that index can be recreated if manually deleted."""
+    session_id = f"index_recreation_test_{str(ULID())}"
+    history = RedisChatMessageHistory(session_id=session_id, redis_url=redis_url)
+
+    try:
+        # Add a message to ensure index is working
+        history.add_message(HumanMessage(content="Test message"))
+        assert len(history.messages) == 1
+
+        # Manually delete the index
+        redis_client = Redis.from_url(redis_url)
+        try:
+            redis_client.ft(history.index_name).dropindex()
+        except Exception:
+            pass  # Index might not exist
+
+        # Create new instance - should recreate index
+        history2 = RedisChatMessageHistory(session_id=session_id, redis_url=redis_url)
+
+        # Should be able to add messages again
+        history2.add_message(HumanMessage(content="After recreation"))
+        messages = history2.messages
+        # Note: Original message might be gone since index was dropped
+        assert len(messages) >= 1
+        assert any("After recreation" in msg.content for msg in messages)
+
+    finally:
+        try:
+            history.delete()
+            history2.delete()
+        except Exception:
+            pass
+
+
+def test_multiple_instances_same_session(redis_url: str) -> None:
+    """Test multiple instances accessing the same session."""
+    session_id = f"multi_instance_test_{str(ULID())}"
+
+    history1 = RedisChatMessageHistory(session_id=session_id, redis_url=redis_url)
+    history2 = RedisChatMessageHistory(session_id=session_id, redis_url=redis_url)
+
+    try:
+        # Add message with first instance
+        history1.add_message(HumanMessage(content="From instance 1"))
+
+        # Read with second instance
+        messages = history2.messages
+        assert len(messages) == 1
+        assert messages[0].content == "From instance 1"
+
+        # Add message with second instance
+        history2.add_message(AIMessage(content="From instance 2"))
+
+        # Read with first instance
+        messages = history1.messages
+        assert len(messages) == 2
+        assert messages[0].content == "From instance 1"
+        assert messages[1].content == "From instance 2"
+
+    finally:
+        history1.clear()
+
+
+def test_search_with_empty_query(chat_history: RedisChatMessageHistory) -> None:
+    """Test search with empty query string."""
+    chat_history.add_message(HumanMessage(content="Test message"))
+
+    # Empty query should return no results or all results depending on implementation
+    results = chat_history.search_messages("")
+    # This behavior might vary - just ensure it doesn't crash
+    assert isinstance(results, list)
+    assert results == []
+
+
+def test_message_with_none_content() -> None:
+    """Test that messages with None content are handled properly."""
+    # This should raise an error during message creation, not in our code
+    with pytest.raises((TypeError, ValueError)):
+        HumanMessage(content=None)  # type: ignore
+
+
+def test_redis_connection_recovery(redis_url: str) -> None:
+    """Test behavior when Redis connection is temporarily lost."""
+    session_id = f"connection_test_{str(ULID())}"
+    history = RedisChatMessageHistory(session_id=session_id, redis_url=redis_url)
+
+    try:
+        # Add a message normally
+        history.add_message(HumanMessage(content="Before connection issue"))
+        assert len(history.messages) == 1
+
+        # Simulate connection issue by closing the connection
+        # Note: This is a basic test - real connection recovery would be more complex
+        history.redis_client.connection_pool.disconnect()
+
+        # Try to add another message - should work due to connection pooling
+        history.add_message(HumanMessage(content="After connection issue"))
+        messages = history.messages
+        assert len(messages) == 2
+
+    finally:
+        history.delete()
+
+
+def test_very_long_key_prefix(redis_url: str) -> None:
+    """Test with very long key prefix."""
+    long_prefix = "very_long_prefix_" * 10 + ":"  # ~170 characters
+    session_id = f"test_{str(ULID())}"
+
+    history = RedisChatMessageHistory(
+        session_id=session_id, redis_url=redis_url, key_prefix=long_prefix
+    )
+
+    try:
+        history.add_message(HumanMessage(content="Test with long prefix"))
+        messages = history.messages
+        assert len(messages) == 1
+        assert messages[0].content == "Test with long prefix"
+    finally:
+        history.delete()
+
+
+def test_special_characters_in_key_prefix(redis_url: str) -> None:
+    """Test with special characters in key prefix."""
+    special_prefix = "test-prefix_with.special@chars:"
+    session_id = f"test_{str(ULID())}"
+
+    history = RedisChatMessageHistory(
+        session_id=session_id, redis_url=redis_url, key_prefix=special_prefix
+    )
+
+    try:
+        history.add_message(HumanMessage(content="Test with special prefix"))
+        messages = history.messages
+        assert len(messages) == 1
+        assert messages[0].content == "Test with special prefix"
+    finally:
+        history.delete()
+
+
+def test_negative_ttl(redis_url: str) -> None:
+    """Test behavior with negative TTL."""
+    session_id = f"negative_ttl_test_{str(ULID())}"
+
+    # Negative TTL should either be rejected or treated as no TTL
+    try:
+        history = RedisChatMessageHistory(
+            session_id=session_id, redis_url=redis_url, ttl=-1
+        )
+
+        history.add_message(HumanMessage(content="Negative TTL test"))
+        messages = history.messages
+        # Should either work (treating -1 as no TTL) or fail gracefully
+        assert isinstance(messages, list)
+
+    except (ValueError, TypeError):
+        # It's acceptable to reject negative TTL
+        pass
+    finally:
+        history.delete()
+
+
+def test_pagination_in_clear_method(redis_url: str) -> None:
+    """Test that the pagination in clear() method works correctly."""
+    session_id = f"pagination_clear_test_{str(ULID())}"
+    history = RedisChatMessageHistory(session_id=session_id, redis_url=redis_url)
+
+    try:
+        # Add more messages than the page size (50)
+        for i in range(75):
+            history.add_message(HumanMessage(content=f"Message {i}"))
+
+        assert len(history.messages) == 75
+
+        # Clear should handle pagination correctly
+        history.clear()
+        assert len(history.messages) == 0
+
+    finally:
+        history.delete()
+
+
+def test_json_serialization_edge_cases(chat_history: RedisChatMessageHistory) -> None:
+    """Test edge cases in JSON serialization."""
+    # Test with content that might cause JSON issues
+    problematic_content = """{"nested": "json", "array": [1, 2, 3], "null": null}"""
+
+    chat_history.add_message(HumanMessage(content=problematic_content))
+
+    messages = chat_history.messages
+    assert len(messages) == 1
+    assert messages[0].content == problematic_content
+
+
+def test_timestamp_precision(redis_url: str) -> None:
+    """Test timestamp precision and uniqueness."""
+    session_id = f"timestamp_test_{str(ULID())}"
+    history = RedisChatMessageHistory(session_id=session_id, redis_url=redis_url)
+
+    try:
+        # Add messages in very quick succession
+        import time
+
+        start_time = time.time()
+
+        for i in range(10):
+            history.add_message(HumanMessage(content=f"Timestamp test {i}"))
+
+        end_time = time.time()
+
+        messages = history.messages
+        assert len(messages) == 10
+
+        # Verify all messages are in order
+        for i, message in enumerate(messages):
+            assert message.content == f"Timestamp test {i}"
+
+        # Test took less than a second but all messages should be ordered
+        assert end_time - start_time < 1.0
+
+    finally:
+        history.delete()

--- a/libs/redis/tests/unit_tests/test_chat_message_history.py
+++ b/libs/redis/tests/unit_tests/test_chat_message_history.py
@@ -1,381 +1,112 @@
-import json
-from typing import Any, Dict, Generator, List
-from unittest.mock import Mock, call, patch
+from unittest.mock import patch
 
 import pytest
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
-from redis.commands.search.field import NumericField, TagField, TextField
-from redis.commands.search.indexDefinition import IndexDefinition
-from redis.commands.search.query import Query
-from redis.commands.search.result import Result
-from redis.exceptions import ResponseError
 
 from langchain_redis import RedisChatMessageHistory
 
 
-class MockRedisJSON:
-    def __init__(self) -> None:
-        self.data: Dict[str, Any] = {}
+class TestRedisChatMessageHistoryMinimal:
+    """Minimal unit tests focusing on input validation and utility methods."""
 
-    def set(self, key: str, path: str, value: Any) -> None:
-        self.data[key] = value
+    def test_session_id_validation_empty_string(self) -> None:
+        """Test that empty session_id raises ValueError."""
+        with patch("langchain_redis.chat_message_history.SearchIndex"), patch(
+            "redis.Redis.from_url"
+        ):
+            with pytest.raises(
+                ValueError, match="session_id must be a non-empty, valid string"
+            ):
+                RedisChatMessageHistory(session_id="")
 
-    def get(self, key: str) -> Any:
-        return self.data.get(key)
+    def test_session_id_validation_none(self) -> None:
+        """Test that None session_id raises ValueError."""
+        with patch("langchain_redis.chat_message_history.SearchIndex"), patch(
+            "redis.Redis.from_url"
+        ):
+            with pytest.raises(
+                ValueError, match="session_id must be a non-empty, valid string"
+            ):
+                RedisChatMessageHistory(session_id=None)  # type: ignore
 
-    def _load_data(self, key: str, data: Any) -> None:
-        self.data[key] = data
+    def test_id_property_returns_session_id(self) -> None:
+        """Test that id property returns session_id."""
+        with patch("langchain_redis.chat_message_history.SearchIndex"), patch(
+            "redis.Redis.from_url"
+        ):
+            history = RedisChatMessageHistory(session_id="test_session")
+            assert history.id == "test_session"
 
+    def test_message_key_generation_with_provided_id(self) -> None:
+        """Test message key generation with provided message_id."""
+        with patch("langchain_redis.chat_message_history.SearchIndex"), patch(
+            "redis.Redis.from_url"
+        ):
+            history = RedisChatMessageHistory(session_id="test_session")
+            key = history._message_key("msg123")
+            assert key == "chat:test_session:msg123"
 
-class MockRedis:
-    def __init__(self) -> None:
-        self.indices: Dict[str, Any] = {}
-        self._json = MockRedisJSON()
-
-    def json(self) -> MockRedisJSON:
-        return self._json
-
-    def delete(self, *keys: str) -> None:
-        for key in keys:
-            self._json.data.pop(key, None)
-
-    def ft(self, index_name: str) -> "MockFT":
-        if index_name not in self.indices:
-            self.indices[index_name] = MockFT(self, index_name)
-        return self.indices[index_name]
-
-    def keys(self, pattern: str) -> List[str]:
-        return [key for key in self._json.data.keys() if key.startswith(pattern)]
-
-    def execute_command(self, *args: Any, **kwargs: Any) -> List[Any]:
-        if args[0] == "FT.SEARCH":
-            results = [
-                ["id", key, "json", json.dumps(value)]
-                for key, value in self._json.data.items()
-            ]
-            return [len(results), *results]
-        else:
-            return []
-
-    def client_setinfo(self, attr: str, value: str) -> None:
-        pass
-
-
-class MockFT:
-    def __init__(self, redis: MockRedis, index_name: str) -> None:
-        self.redis = redis
-        self.index_name = index_name
-
-    def create_index(self, *args: Any, **kwargs: Any) -> None:
-        pass
-
-    def info(self) -> Dict[str, str]:
-        return {"index_name": self.index_name}
-
-    def search(self, query: Any) -> Mock:
-        results = Mock()
-        results.docs = [
-            Mock(id=k, json=json.dumps(v)) for k, v in self.redis._json.data.items()
-        ]
-        results.total = len(results.docs)
-        return results
-
-
-class TestRedisChatMessageHistory:
-    @pytest.fixture
-    def mock_redis(self) -> MockRedis:
-        return MockRedis()
-
-    @pytest.fixture
-    def chat_history(
-        self, mock_redis: MockRedis
-    ) -> Generator[RedisChatMessageHistory, None, None]:
-        with patch("redis.Redis.from_url", return_value=mock_redis):
+    def test_message_key_generation_with_custom_prefix(self) -> None:
+        """Test message key generation with custom key_prefix."""
+        with patch("langchain_redis.chat_message_history.SearchIndex"), patch(
+            "redis.Redis.from_url"
+        ):
             history = RedisChatMessageHistory(
-                session_id="test_session", redis_url="redis://localhost:6379"
+                session_id="test_session", key_prefix="custom:"
             )
-            yield history
+            key = history._message_key("msg123")
+            assert key == "custom:test_session:msg123"
 
-    def test_initialization(self, chat_history: RedisChatMessageHistory) -> None:
-        assert isinstance(chat_history, RedisChatMessageHistory)
-        assert chat_history.session_id == "test_session"
+    def test_message_key_generation_auto_id(self) -> None:
+        """Test message key generation with auto-generated message_id."""
+        with patch("langchain_redis.chat_message_history.SearchIndex"), patch(
+            "redis.Redis.from_url"
+        ):
+            history = RedisChatMessageHistory(session_id="test_session")
+            key = history._message_key()
 
-    def test_add_message(self, chat_history: RedisChatMessageHistory) -> None:
-        human_message = HumanMessage(content="Hello, AI!")
-        ai_message = AIMessage(content="Hello, human!")
-        system_message = SystemMessage(content="System message")
+            # Should have format: prefix:session:ulid
+            parts = key.split(":")
+            assert len(parts) == 3
+            assert parts[0] == "chat"
+            assert parts[1] == "test_session"
+            assert len(parts[2]) > 0  # ULID should be generated
 
-        chat_history.add_message(human_message)
-        chat_history.add_message(ai_message)
-        chat_history.add_message(system_message)
+    def test_search_messages_empty_query_returns_empty_list(self) -> None:
+        """Test that empty search query returns empty list without Redis calls."""
+        with patch("langchain_redis.chat_message_history.SearchIndex"), patch(
+            "redis.Redis.from_url"
+        ):
+            history = RedisChatMessageHistory(session_id="test_session")
 
-        messages = chat_history.messages
-        assert len(messages) == 3
-        assert isinstance(messages[0], HumanMessage)
-        assert isinstance(messages[1], AIMessage)
-        assert isinstance(messages[2], SystemMessage)
-        assert messages[0].content == "Hello, AI!"
-        assert messages[1].content == "Hello, human!"
-        assert messages[2].content == "System message"
+            # These should return empty list immediately
+            assert history.search_messages("") == []
+            assert history.search_messages(None) == []  # type: ignore
 
-    def test_clear(self, chat_history: RedisChatMessageHistory) -> None:
-        chat_history.add_message(HumanMessage(content="Test message"))
-        assert len(chat_history.messages) == 1
+    def test_default_parameters(self) -> None:
+        """Test that default parameters are set correctly."""
+        with patch("langchain_redis.chat_message_history.SearchIndex"), patch(
+            "redis.Redis.from_url"
+        ):
+            history = RedisChatMessageHistory(session_id="test_session")
 
-        chat_history.clear()
-        assert len(chat_history.messages) == 0
+            assert history.session_id == "test_session"
+            assert history.key_prefix == "chat:"
+            assert history.ttl is None
+            assert history.index_name == "idx:chat_history"
 
-    def test_search_messages(self, chat_history: RedisChatMessageHistory) -> None:
-        with patch.object(chat_history.redis_client, "ft") as mock_ft:
-            mock_search = Mock()
-            mock_ft.return_value.search = mock_search
-
-            # Create a mock search result
-            mock_doc = Mock()
-            mock_doc.id = "test_key"
-            mock_doc.json = json.dumps(
-                {
-                    "data": {
-                        "content": "What's the weather like today?",
-                        "additional_kwargs": {},
-                        "type": "human",
-                    }
-                }
-            )
-
-            mock_result = Mock(spec=Result)
-            mock_result.docs = [mock_doc]
-            mock_result.total = 1
-
-            mock_search.return_value = mock_result
-
-            results = chat_history.search_messages("weather", limit=5)
-
-            # Check that ft was called with the correct index name
-            mock_ft.assert_called_once_with(chat_history.index_name)
-
-            # Check that search was called with the correct query
-            mock_search.assert_called_once()
-            query_arg = mock_search.call_args[0][0]
-
-            assert isinstance(query_arg, Query)
-
-            # Check the query string
-            expected_query_string = (
-                f"(@session_id:{{{chat_history.session_id}}}) (@content:weather)"
-            )
-            assert query_arg.query_string() == expected_query_string
-
-            # Check the additional arguments
-            args = query_arg.get_args()
-            assert "(@session_id:{test_session}) (@content:weather)" in args
-            assert "SORTBY" in args
-            assert "timestamp" in args
-            assert "ASC" in args
-            assert "LIMIT" in args
-            assert 0 in args
-            assert 5 in args
-
-            # Check the returned results
-            assert len(results) == 1
-            assert results[0]["content"] == "What's the weather like today?"
-            assert results[0]["type"] == "human"
-
-    def test_len(self, chat_history: RedisChatMessageHistory) -> None:
-        chat_history.add_message(HumanMessage(content="Message 1"))
-        chat_history.add_message(AIMessage(content="Message 2"))
-        chat_history.add_message(HumanMessage(content="Message 3"))
-
-        assert len(chat_history) == 3
-
-    def test_ttl(self, chat_history: RedisChatMessageHistory) -> None:
-        chat_history.add_message(HumanMessage(content="Test message"))
-        assert len(chat_history.messages) == 1
-
-        # Manually clear the data to simulate TTL expiration
-        chat_history.redis_client._json.data.clear()  # type: ignore[attr-defined]
-        assert len(chat_history.messages) == 0
-
-    def test_ensure_index(self, chat_history: RedisChatMessageHistory) -> None:
-        with patch.object(chat_history.redis_client, "ft") as mock_ft:
-            # Mock the info method to raise the specific ResponseError
-            mock_ft.return_value.info.side_effect = ResponseError("Unknown index name")
-
-            # Call _ensure_index explicitly
-            chat_history._ensure_index()
-
-            # Check the calls made to ft
-            assert mock_ft.call_count == 2
-            assert mock_ft.call_args_list == [
-                call(chat_history.index_name),
-                call(chat_history.index_name),
-            ]
-
-            # Check info was called
-            mock_ft.return_value.info.assert_called_once()
-
-            # Check create_index was called and verify its arguments
-            mock_ft.return_value.create_index.assert_called_once()
-            create_index_args = mock_ft.return_value.create_index.call_args
-
-            # Check the schema
-            schema = create_index_args[0][0]
-            assert len(schema) == 4
-
-            # Check each field in the schema
-            assert isinstance(schema[0], TagField)
-            assert schema[0].redis_args() == [
-                "$.session_id",
-                "AS",
-                "session_id",
-                "TAG",
-                "SEPARATOR",
-                ",",
-            ]
-
-            assert isinstance(schema[1], TextField)
-            assert schema[1].redis_args() == [
-                "$.data.content",
-                "AS",
-                "content",
-                "TEXT",
-                "WEIGHT",
-                1.0,
-            ]
-
-            assert isinstance(schema[2], TagField)
-            assert schema[2].redis_args() == [
-                "$.type",
-                "AS",
-                "type",
-                "TAG",
-                "SEPARATOR",
-                ",",
-            ]
-
-            assert isinstance(schema[3], NumericField)
-            assert schema[3].redis_args() == [
-                "$.timestamp",
-                "AS",
-                "timestamp",
-                "NUMERIC",
-            ]
-
-            # Check the index definition in the keyword arguments
-            index_definition = create_index_args[1].get("definition")
-            assert isinstance(index_definition, IndexDefinition)
-
-            # Check the index definition args
-            assert "ON" in index_definition.args
-            assert "JSON" in index_definition.args
-            assert "PREFIX" in index_definition.args
-            assert 1 in index_definition.args  # The number of prefixes
-            assert chat_history.key_prefix in index_definition.args
-
-    def test_add_user_message(self, chat_history: RedisChatMessageHistory) -> None:
-        chat_history.add_user_message("Hello, AI!")
-        messages = chat_history.messages
-        assert len(messages) == 1
-        assert isinstance(messages[0], HumanMessage)
-        assert messages[0].content == "Hello, AI!"
-
-    def test_add_ai_message(self, chat_history: RedisChatMessageHistory) -> None:
-        chat_history.add_ai_message("Hello, human!")
-        messages = chat_history.messages
-        assert len(messages) == 1
-        assert isinstance(messages[0], AIMessage)
-        assert messages[0].content == "Hello, human!"
-
-    def test_multiple_sessions(self, mock_redis: MockRedis) -> None:
-        # First session
-        with patch("redis.Redis.from_url", return_value=mock_redis):
-            history1 = RedisChatMessageHistory(
-                session_id="session1", redis_url="redis://localhost:6379"
-            )
-            history1.add_user_message("Hello, AI!")
-            history1.add_ai_message("Hello, how can I help you?")
-            history1.add_user_message("Tell me a joke.")
-            history1.add_ai_message(
-                "Why did the chicken cross the road? To get to the other side!"
-            )
-
-        # Ensure the messages are added correctly in the first session
-        messages1 = history1.messages
-        assert len(messages1) == 4
-        assert messages1[0].content == "Hello, AI!"
-        assert messages1[1].content == "Hello, how can I help you?"
-        assert messages1[2].content == "Tell me a joke."
-        assert (
-            messages1[3].content
-            == "Why did the chicken cross the road? To get to the other side!"
-        )
-
-        # Second session
-        with patch("redis.Redis.from_url", return_value=mock_redis):
-            history2 = RedisChatMessageHistory(
-                session_id="session1", redis_url="redis://localhost:6379"
-            )
-
-        # Ensure the history is maintained in the second session
-        messages2 = history2.messages
-        assert len(messages2) == 4
-        assert messages2[0].content == "Hello, AI!"
-        assert messages2[1].content == "Hello, how can I help you?"
-        assert messages2[2].content == "Tell me a joke."
-        assert (
-            messages2[3].content
-            == "Why did the chicken cross the road? To get to the other side!"
-        )
-
-    def test_add_user_and_ai_messages(
-        self, chat_history: RedisChatMessageHistory
-    ) -> None:
-        chat_history.add_user_message("Hello!")
-        chat_history.add_ai_message("Hi there!")
-
-        messages = chat_history.messages
-        assert len(messages) == 2
-        assert isinstance(messages[0], HumanMessage)
-        assert isinstance(messages[1], AIMessage)
-        assert messages[0].content == "Hello!"
-        assert messages[1].content == "Hi there!"
-
-    def test_session_id_escaping(self, mock_redis: MockRedis) -> None:
-        """Test that session IDs with special characters are properly escaped in Redis
-        search queries."""
-        # Test with a UUID containing hyphens (common case that caused the original bug)
-        uuid_session_id = "550e8400-e29b-41d4-a716-446655440000"
-
-        with patch("redis.Redis.from_url", return_value=mock_redis):
+    def test_custom_parameters(self) -> None:
+        """Test initialization with custom parameters."""
+        with patch("langchain_redis.chat_message_history.SearchIndex"), patch(
+            "redis.Redis.from_url"
+        ):
             history = RedisChatMessageHistory(
-                session_id=uuid_session_id, redis_url="redis://localhost:6379"
+                session_id="custom_session",
+                key_prefix="custom:",
+                ttl=7200,
+                index_name="custom_index",
             )
 
-        # Test the _escape_session_id method directly
-        escaped_session_id = history._escape_session_id()
-        expected_escaped = "550e8400\\-e29b\\-41d4\\-a716\\-446655440000"
-        assert escaped_session_id == expected_escaped
-
-        # Mock the search to verify escaped session ID is used in queries
-        with patch.object(history.redis_client, "ft") as mock_ft:
-            mock_search_result = Mock()
-            mock_search_result.docs = []
-            mock_search_result.total = 0
-            mock_ft.return_value.search.return_value = mock_search_result
-
-            # Test that all query methods use escaped session ID
-            _ = history.messages
-            history.clear()
-            history.search_messages("test")
-            _ = len(history)
-
-            # Verify all queries use escaped session ID
-            assert mock_ft.return_value.search.call_count == 4
-
-            for call in mock_ft.return_value.search.call_args_list:
-                query_arg = call[0][0]
-                query_string = query_arg.query_string()
-
-                # Verify the query contains the escaped session ID, not the original
-                assert expected_escaped in query_string
-                assert uuid_session_id not in query_string
+            assert history.session_id == "custom_session"
+            assert history.key_prefix == "custom:"
+            assert history.ttl == 7200
+            assert history.index_name == "custom_index"


### PR DESCRIPTION
Fixes the bug with session IDs and also updates to use RedisVL for internals of search and index handling for simplicity. Adds several new chat history integration tests and simplifies the unit test code since we cover a ton of ground with integration tests.

Also fixes an issue where timestamps in the key were causing some collisions. Updated to use ULIDs instead and added the message_id to the object too.