### PR TITLE
chore: Bump version for 0.2.5 release

### DIFF
--- a/libs/redis/pyproject.toml
+++ b/libs/redis/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-redis"
-version = "0.3.4"
+version = "0.2.5"
 description = "An integration package connecting Redis and LangChain for AI working memory"
 authors = ["Brian Sam-Bodden <bsb@redis.com>"]
 readme = "README.md"


### PR DESCRIPTION
Bumps the version to prepare for 0.2.5 release.