### PR TITLE
fix: update setuptools to 83.0.0

### DIFF
--- a/libs/redis/poetry.lock
+++ b/libs/redis/poetry.lock
@@ -2660,14 +2660,14 @@ video = ["transformers[video]"]
 
 [[package]]
 name = "setuptools"
-version = "80.9.0"
+version = "83.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["test"]
 files = [
-    {file = "setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922"},
-    {file = "setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"},
+    {file = "setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3"},
+    {file = "setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef"},
 ]
 
 [package.extras]


### PR DESCRIPTION
## Summary
- update `setuptools` from 80.9.0 to 83.0.0 in `libs/redis/poetry.lock`
- resolve GHSA-h35f-9h28-mq5c / CVE-2026-59890 (Dependabot alert #59)
- keep the change scoped to the affected lockfile entry

## Test Plan
- [x] `poetry check --lock --directory libs/redis`
- [x] `git diff --check`

## Notes
- Package hashes and `Requires-Python` metadata were verified against the PyPI 83.0.0 release metadata.