### PR TITLE
fix: pin allowed_objects="core" for langchain_core.load.loads() calls in cache.py

### DIFF
--- a/libs/redis/langchain_redis/cache.py
+++ b/libs/redis/langchain_redis/cache.py
@@ -226,7 +226,11 @@ class RedisCache(BaseCache):
         key = self._key(prompt, llm_string)
         result = self.redis.json().get(key)
         if result:
-            return [loads(json.dumps(result))]
+            # `allowed_objects="core"` matches the current default explicitly, so
+            # this keeps existing behavior stable when langchain-core changes its
+            # default (see LangChainPendingDeprecationWarning) instead of silently
+            # picking up a narrower allowlist on a future langchain-core upgrade.
+            return [loads(json.dumps(result), allowed_objects="core")]
         return None
 
     def update(self, prompt: str, llm_string: str, return_val: RETURN_VAL_TYPE) -> None:
@@ -491,7 +495,7 @@ class RedisSemanticCache(BaseCache):
                 if result.get("metadata", {}).get("llm_string") == llm_string:
                     try:
                         return [
-                            loads(gen_str)
+                            loads(gen_str, allowed_objects="core")
                             for gen_str in json.loads(result.get("response"))
                         ]
                     except (json.JSONDecodeError, TypeError):
@@ -680,7 +684,7 @@ class RedisSemanticCache(BaseCache):
                 if result.get("metadata", {}).get("llm_string") == llm_string:
                     try:
                         return [
-                            loads(gen_str)
+                            loads(gen_str, allowed_objects="core")
                             for gen_str in json.loads(result.get("response"))
                         ]
                     except (json.JSONDecodeError, TypeError):
@@ -852,7 +856,10 @@ class LangCacheSemanticCache(BaseCache):
 
         first = results[0]
         try:
-            return [loads(s) for s in json.loads(first.get("response", "[]"))]
+            return [
+                loads(s, allowed_objects="core")
+                for s in json.loads(first.get("response", "[]"))
+            ]
         except (json.JSONDecodeError, TypeError):
             return None
 


### PR DESCRIPTION
## Problem
Every cache read in `RedisCache`, `RedisSemanticCache`, and
`LangCacheSemanticCache` calls `langchain_core.load.loads()` without
an explicit `allowed_objects` argument, which currently emits:

    LangChainPendingDeprecationWarning: The default value of
    `allowed_objects` will change in a future version. Pass an
    explicit list of allowed classes (or 'messages' for untrusted
    input that contains only chat messages) to suppress this warning.

on every single cache lookup.

## Fix
Pass `allowed_objects="core"` explicitly — this is the same value
langchain-core already uses as its current default, so behavior is
completely unchanged today. The difference is that a future
langchain-core upgrade won't silently narrow what this cache can
deserialize (e.g. to `'messages'` only), which could otherwise break
existing caches holding `ChatGeneration` objects with tool calls,
function calls, or other non-message-only content.

No other files in the package call `langchain_core.load.loads()`.

## Tests
- 62 passed in `tests/unit_tests` with `--disable-socket` (1
  pre-existing, unrelated failure due to a missing optional
  `sentence-transformers` dependency — fails identically on
  unmodified `main`)
- Ran with `-W error::...LangChainPendingDeprecationWarning`: zero
  warnings raised, confirming the fix
- `ruff check` / `ruff format --diff` / `ruff check --select I`: clean
- `mypy`: no issues found