### PR TITLE
docs: fix wrong kwarg and typo in delete() docstring

### DIFF
--- a/libs/redis/langchain_redis/vectorstores.py
+++ b/libs/redis/langchain_redis/vectorstores.py
@@ -829,8 +829,8 @@ class RedisVectorStore(VectorStore):
             from langchain_openai import OpenAIEmbeddings
 
             vector_store = RedisVectorStore(
+                embeddings=OpenAIEmbeddings(),
                 index_name="langchain-demo",
-                embedding=OpenAIEmbeddings(),
                 redis_url="redis://localhost:6379",
             )
 
@@ -839,7 +839,7 @@ class RedisVectorStore(VectorStore):
 
             result = vector_store.delete(ids=ids_to_delete)
             if result:
-                print("Documents were succesfully deleted")
+                print("Documents were successfully deleted")
             else:
                 print("No Documents were deleted")
             ```


### PR DESCRIPTION
## Problem

Two issues in the `RedisVectorStore.delete()` docstring example:

**1. Wrong keyword argument**

```python
# Wrong (current)
vector_store = RedisVectorStore(
    index_name="langchain-demo",
    embedding=OpenAIEmbeddings(),  # ← not a valid kwarg
    ...
)

# Correct (fixed)
vector_store = RedisVectorStore(
    embeddings=OpenAIEmbeddings(),  # ← first positional arg
    index_name="langchain-demo",
    ...
)
```

`embedding=` is not a constructor parameter. It falls silently into `**kwargs` → `RedisConfig`, which ignores it, so the store ends up with no embeddings. Every other docstring example in the same file already uses `embeddings=` correctly.

**2. Typo**

`"Documents were succesfully deleted"` → `"Documents were successfully deleted"`

## Changes

- `libs/redis/langchain_redis/vectorstores.py`: fix `embedding=` → `embeddings=` and `succesfully` → `successfully` in `delete()` docstring example