### PR TITLE
docs: fix wrong 'embedding=' kwarg in RedisVectorStore docstring examples

### DIFF
--- a/libs/redis/langchain_redis/vectorstores.py
+++ b/libs/redis/langchain_redis/vectorstores.py
@@ -87,8 +87,8 @@ def maximal_marginal_relevance(
 
         embeddings = OpenAIEmbeddings()
         vector_store = RedisVectorStore(
+            embeddings=embeddings,
             index_name="langchain-demo",
-            embedding=embeddings,
             redis_url="redis://localhost:6379",
         )
 
@@ -173,8 +173,8 @@ class RedisVectorStore(VectorStore):
         from langchain_openai import OpenAIEmbeddings
 
         vector_store = RedisVectorStore(
+            embeddings=OpenAIEmbeddings(),
             index_name="langchain-demo",
-            embedding=OpenAIEmbeddings(),
             redis_url="redis://localhost:6379",
         )
         ```
@@ -192,7 +192,7 @@ class RedisVectorStore(VectorStore):
         redis_client = Redis.from_url("redis://localhost:6379")
 
         store = RedisVectorStore(
-            embedding=OpenAIEmbeddings(),
+            embeddings=OpenAIEmbeddings(),
             index_name="langchain-demo",
             redis_client=redis_client
         )
@@ -445,8 +445,8 @@ class RedisVectorStore(VectorStore):
             from langchain_openai import OpenAIEmbeddings
 
             vector_store = RedisVectorStore(
+                embeddings=OpenAIEmbeddings(),
                 index_name="langchain-demo",
-                embedding=OpenAIEmbeddings(),
                 redis_url="redis://localhost:6379",
             )
 
@@ -1339,8 +1339,8 @@ class RedisVectorStore(VectorStore):
             from langchain_openai import OpenAIEmbeddings
 
             vector_store = RedisVectorStore(
+                embeddings=OpenAIEmbeddings(),
                 index_name="langchain-demo",
-                embedding=OpenAIEmbeddings(),
                 redis_url="redis://localhost:6379",
             )
 


### PR DESCRIPTION
## Problem

`RedisVectorStore.__init__` takes `embeddings` as its first positional argument — not `embedding`. Passing `embedding=...` as a keyword silently falls through `**kwargs` into `RedisConfig`, which has no such field, so Pydantic ignores it (no `extra='forbid'`). The store is created without an embeddings object but raises no error — the failure only surfaces later, at search/add time, with a confusing traceback.

Five docstring examples across `vectorstores.py` had this bug:

| Location | Wrong | Correct |
|---|---|---|
| `maximal_marginal_relevance()` | `embedding=embeddings` | `embeddings=embeddings` |
| Class-level "Instantiate" example | `embedding=OpenAIEmbeddings()` | `embeddings=OpenAIEmbeddings()` |
| Class-level "Instantiate from existing connection" | `embedding=OpenAIEmbeddings()` | `embeddings=OpenAIEmbeddings()` |
| `add_texts()` | `embedding=OpenAIEmbeddings()` | `embeddings=OpenAIEmbeddings()` |
| `similarity_search_with_score()` | `embedding=OpenAIEmbeddings()` | `embeddings=OpenAIEmbeddings()` |

Note: `from_texts()`, `from_documents()`, and `from_existing_index()` correctly use `embedding` as their own parameter name — those are not changed.

## Changes

- `libs/redis/langchain_redis/vectorstores.py`: fix `embedding=` → `embeddings=` in 5 docstring examples