### PR TITLE
fix: use async vectorizer in RedisSemanticCache.aupdate()

### DIFF
--- a/libs/redis/langchain_redis/cache.py
+++ b/libs/redis/langchain_redis/cache.py
@@ -711,7 +711,7 @@ class RedisSemanticCache(BaseCache):
                 The value is a list of `Generation` objects (or subclasses).
         """
         serialized_response = json.dumps([dumps(gen) for gen in return_val])
-        vector = self.cache._vectorize_prompt(prompt)
+        vector = await self.cache._avectorize_prompt(prompt)
 
         await self.cache.astore(
             prompt=prompt,


### PR DESCRIPTION
## Problem

`RedisSemanticCache.aupdate()` calls the **synchronous** `_vectorize_prompt()` to compute the embedding vector, despite being an `async` method:

```python
# Before (wrong)
async def aupdate(self, prompt, llm_string, return_val):
    ...
    vector = self.cache._vectorize_prompt(prompt)   # ← sync, blocks event loop
    await self.cache.astore(...)
```

This blocks the event loop for the entire duration of the embedding call — exactly what async methods are meant to avoid, and the main reason to use `aupdate` over `update` in the first place.

## Fix

Use the async counterpart, consistent with how `alookup()` already works:

```python
# After (correct)
async def aupdate(self, prompt, llm_string, return_val):
    ...
    vector = await self.cache._avectorize_prompt(prompt)  # ← non-blocking
    await self.cache.astore(...)
```

## Changes

- `libs/redis/langchain_redis/cache.py`: one-line fix in `RedisSemanticCache.aupdate()`