### PR TITLE
fix: sync version.py with pyproject.toml (0.3.0 → 0.2.5)

### DIFF
--- a/libs/redis/langchain_redis/version.py
+++ b/libs/redis/langchain_redis/version.py
@@ -1,5 +1,5 @@
 from redisvl.version import __version__ as __redisvl_version__  # type: ignore
 
-__version__ = "0.3.0"
+__version__ = "0.2.5"
 __lib_name__ = f"langchain-redis_v{__version__}"
 __full_lib_name__ = f"redis-py(redisvl_v{__redisvl_version__};{__lib_name__})"


### PR DESCRIPTION
## Problem

`libs/redis/langchain_redis/version.py` was introduced in #101 with a hardcoded version that doesn't match the package's canonical version in `pyproject.toml`:

| File | Version |
|---|---|
| `version.py` | `0.3.0` ❌ |
| `pyproject.toml` | `0.2.5` ✅ |
| PyPI (latest release) | `0.2.5` ✅ |

`__version__` from `version.py` is used to build `__full_lib_name__`, which is sent to the Redis server on every connection via `CLIENT SETINFO LIB-NAME`. With the wrong version, server-side telemetry and debugging are inaccurate.

## Fix

Align `version.py` with `pyproject.toml`.

## Changes

- `libs/redis/langchain_redis/version.py`: `"0.3.0"` → `"0.2.5"`