### PR TITLE
DOC: RedisVectorStore.add_texts missing Raises section in docstring

### DIFF
--- a/libs/redis/langchain_redis/vectorstores.py
+++ b/libs/redis/langchain_redis/vectorstores.py
@@ -439,6 +439,14 @@ class RedisVectorStore(VectorStore):
         Returns:
             List of ids from adding the texts into the vector store.
 
+        Raises:
+            ValueError: If `metadatas` is provided and its length does not
+                match the number of `texts`.
+            ValueError: If `keys` is provided and its length does not
+                match the number of `texts`.
+            ValueError: If `ids` is provided (via `kwargs`) and its length
+                does not match the number of `texts`.
+
         Example:
             ```python
             from langchain_redis import RedisVectorStore


### PR DESCRIPTION
`RedisVectorStore.add_texts()` raises `ValueError` in three documented
scenarios (mismatched length of `metadatas`, `keys`, or `ids` vs `texts`),
but the docstring only mentions this informally in a `Note:` section,
not in a proper `Raises:` section.

This is inconsistent with the rest of the codebase: `chat_message_history.py`
and `config.py` both use `Raises:` sections extensively (13 instances
total), but `vectorstores.py` has none, despite being the largest file
in the package.

Fix: add a `Raises:` section to `add_texts()` documenting all three
ValueError cases, matching the existing convention. 1 file, 8 lines.
10 related unit tests pass unchanged. I have a fix ready and would like
to open a PR.