### PR TITLE
fix: add_texts() returns double-prefixable keys instead of bare ids

### DIFF
--- a/libs/redis/langchain_redis/vectorstores.py
+++ b/libs/redis/langchain_redis/vectorstores.py
@@ -559,8 +559,21 @@ class RedisVectorStore(VectorStore):
         else:
             result = self._index.load(records, ttl=self.ttl)
 
-        # Return list of IDs or empty list if result is None
-        return list(result) if result is not None else []
+        if result is None:
+            return []
+
+        # `SearchIndex.load` returns the full Redis keys it wrote, prefix
+        # included. `delete()` and `get_by_ids()` take bare ids and add that
+        # same prefix themselves, so strip it back off here. Otherwise the ids
+        # this method returns can't be passed to either of those without
+        # ending up double-prefixed.
+        if self.config.key_prefix:
+            full_prefix = f"{self.config.key_prefix}:"
+            return [
+                key[len(full_prefix) :] if key.startswith(full_prefix) else key
+                for key in result
+            ]
+        return list(result)
 
     @classmethod
     def from_texts(

--- a/libs/redis/tests/integration_tests/test_vectorstores_hash.py
+++ b/libs/redis/tests/integration_tests/test_vectorstores_hash.py
@@ -269,8 +269,9 @@ def test_custom_keys(texts: List[str], redis_url: str) -> None:
     )
     vector_store, keys_out = cast(Tuple[RedisVectorStore, List[str]], result)
 
-    # it will append the index key prefix to all keys
-    assert keys_out == [f"{vector_store.key_prefix}:{key}" for key in keys_in]
+    # keys come back without the index key prefix, ready to be passed
+    # straight to get_by_ids()/delete()
+    assert keys_out == keys_in
 
     # Clean up
     vector_store.index.delete(drop=True)
@@ -301,8 +302,8 @@ def test_custom_keys_from_docs(texts: List[str], redis_url: str) -> None:
     )
     # test all keys are stored
     assert client.hget(f"{vector_store.key_prefix}:test_key_2", "text")
-    # test all keys in are the same as the keys_out
-    assert [f"tst8:{key}" for key in keys_in] == keys_out
+    # keys come back without the index key prefix
+    assert keys_out == keys_in
     # Clean up
     vector_store.index.delete(drop=True)
 
@@ -604,6 +605,39 @@ def test_get_by_ids(redis_url: str) -> None:
     assert docs == [
         Document(page_content=doc_1_content, id=doc_1_id),
     ]
+
+    # Clean up
+    vector_store.index.delete(drop=True)
+
+
+def test_add_texts_returned_ids_round_trip(redis_url: str) -> None:
+    """Ids returned by add_texts() must work with get_by_ids() and delete()."""
+    index_name = f"test_index_{str(ULID())}"
+
+    vector_store = RedisVectorStore(
+        embeddings=get_embeddings_for_tests(),
+        index_name=index_name,
+        key_prefix="tst20",
+        redis_url=redis_url,
+    )
+
+    # No keys are passed in, so the returned ids are the only handle the
+    # caller has on these documents.
+    ids = vector_store.add_texts(["foo", "bar"])
+    client = vector_store.index.client
+
+    # An id plus the key prefix is the key that was actually written
+    for id_ in ids:
+        assert client.exists(f"{vector_store.key_prefix}:{id_}")
+
+    docs = vector_store.get_by_ids(ids)
+    assert [doc.id for doc in docs] == ids
+    assert [doc.page_content for doc in docs] == ["foo", "bar"]
+
+    assert vector_store.delete(ids=ids) is True
+    assert vector_store.get_by_ids(ids) == []
+    for id_ in ids:
+        assert not client.exists(f"{vector_store.key_prefix}:{id_}")
 
     # Clean up
     vector_store.index.delete(drop=True)

--- a/libs/redis/tests/integration_tests/test_vectorstores_json.py
+++ b/libs/redis/tests/integration_tests/test_vectorstores_json.py
@@ -278,8 +278,9 @@ def test_custom_keys(texts: List[str], redis_url: str) -> None:
     )
     vector_store, keys_out = cast(Tuple[RedisVectorStore, List[str]], result)
 
-    # it will append the index key prefix to all keys
-    assert keys_out == [f"{vector_store.key_prefix}:{key}" for key in keys_in]
+    # keys come back without the index key prefix, ready to be passed
+    # straight to get_by_ids()/delete()
+    assert keys_out == keys_in
 
     # Clean up
     vector_store.index.delete(drop=True)
@@ -309,8 +310,8 @@ def test_custom_keys_from_docs(texts: List[str], redis_url: str) -> None:
     assert client.json().get(f"{vector_store.key_prefix}:test_key_1", "a") == "b"
     # test all keys are stored
     assert client.json().get(f"{vector_store.key_prefix}:test_key_2", "text")
-    # test all keys in are the same as the keys_out
-    assert [f"tst8:{key}" for key in keys_in] == keys_out
+    # keys come back without the index key prefix
+    assert keys_out == keys_in
     # Clean up
     vector_store.index.delete(drop=True)
 
@@ -617,6 +618,40 @@ def test_get_by_ids(redis_url: str) -> None:
     assert docs == [
         Document(page_content=doc_1_content, id=doc_1_id),
     ]
+
+    # Clean up
+    vector_store.index.delete(drop=True)
+
+
+def test_add_texts_returned_ids_round_trip(redis_url: str) -> None:
+    """Ids returned by add_texts() must work with get_by_ids() and delete()."""
+    index_name = f"test_index_{str(ULID())}"
+
+    vector_store = RedisVectorStore(
+        embeddings=get_embeddings_for_tests(),
+        index_name=index_name,
+        key_prefix="tst20",
+        redis_url=redis_url,
+        storage_type="json",
+    )
+
+    # No keys are passed in, so the returned ids are the only handle the
+    # caller has on these documents.
+    ids = vector_store.add_texts(["foo", "bar"])
+    client = vector_store.index.client
+
+    # An id plus the key prefix is the key that was actually written
+    for id_ in ids:
+        assert client.exists(f"{vector_store.key_prefix}:{id_}")
+
+    docs = vector_store.get_by_ids(ids)
+    assert [doc.id for doc in docs] == ids
+    assert [doc.page_content for doc in docs] == ["foo", "bar"]
+
+    assert vector_store.delete(ids=ids) is True
+    assert vector_store.get_by_ids(ids) == []
+    for id_ in ids:
+        assert not client.exists(f"{vector_store.key_prefix}:{id_}")
 
     # Clean up
     vector_store.index.delete(drop=True)

--- a/libs/redis/tests/unit_tests/test_add_texts_ids.py
+++ b/libs/redis/tests/unit_tests/test_add_texts_ids.py
@@ -120,95 +120,43 @@ def test_add_texts_with_both_keys_and_ids() -> None:
         assert len(result) == 2
 
 
-def _make_vector_store(
-    mock_config: MagicMock,
-    mock_search_index_class: MagicMock,
-    mock_index: MagicMock,
-) -> RedisVectorStore:
-    mock_embeddings = MagicMock()
-    mock_embeddings.embed_query.return_value = [0.1, 0.2, 0.3]
-    mock_embeddings.embed_documents.return_value = [[0.1, 0.2, 0.3]]
-
-    mock_index.schema.fields.values.return_value = []
-    mock_search_index_class.return_value = mock_index
-    mock_search_index_class.from_dict.return_value = mock_index
-
-    mock_config.return_value.index_name = "test_index"
-    mock_config.return_value.key_prefix = "myprefix"
-    mock_config.return_value.embedding_dimensions = 3
-    mock_config.return_value.content_field = "text"
-    mock_config.return_value.embedding_field = "embedding"
-    mock_config.return_value.redis.return_value = MagicMock()
-    mock_config.return_value.index_schema = None
-    mock_config.return_value.schema_path = None
-    mock_config.return_value.from_existing = False
-    mock_config.return_value.storage_type = "JSON"
-    mock_config.return_value.metadata_schema = None
-    mock_config.return_value.vector_datatype = "FLOAT32"
-    mock_config.return_value.default_tag_separator = ","
-    mock_config.return_value.distance_metric = "COSINE"
-    mock_config.return_value.indexing_algorithm = "FLAT"
-
-    return RedisVectorStore(embeddings=mock_embeddings)
-
-
-def test_add_texts_returns_bare_ids_not_prefixed_redis_keys() -> None:
+def test_add_texts_returns_ids_without_key_prefix() -> None:
     """`SearchIndex.load` hands back the full Redis key it wrote (prefix
-    included), but `add_texts` should return the same bare-id format that
-    `delete()` and `get_by_ids()` expect, so callers can round-trip the ids
-    it returns straight back into either method.
+    included), but `delete()` and `get_by_ids()` take bare ids and add that
+    prefix themselves, so `add_texts` has to strip it back off.
     """
     with (
         patch("langchain_redis.vectorstores.RedisConfig") as mock_config,
         patch("langchain_redis.vectorstores.SearchIndex") as mock_search_index_class,
     ):
+        mock_embeddings = MagicMock()
+        mock_embeddings.embed_query.return_value = [0.1, 0.2, 0.3]
+        mock_embeddings.embed_documents.return_value = [[0.1, 0.2, 0.3]]
+
         mock_index = MagicMock()
         mock_index.load.return_value = ["myprefix:mykey"]
-        vector_store = _make_vector_store(
-            mock_config, mock_search_index_class, mock_index
-        )
+        mock_index.schema.fields.values.return_value = []
+        mock_search_index_class.return_value = mock_index
+        mock_search_index_class.from_dict.return_value = mock_index
+
+        mock_config.return_value.index_name = "test_index"
+        mock_config.return_value.key_prefix = "myprefix"
+        mock_config.return_value.embedding_dimensions = 3
+        mock_config.return_value.content_field = "text"
+        mock_config.return_value.embedding_field = "embedding"
+        mock_config.return_value.redis.return_value = MagicMock()
+        mock_config.return_value.index_schema = None
+        mock_config.return_value.schema_path = None
+        mock_config.return_value.from_existing = False
+        mock_config.return_value.storage_type = "JSON"
+        mock_config.return_value.metadata_schema = None
+        mock_config.return_value.vector_datatype = "FLOAT32"
+        mock_config.return_value.default_tag_separator = ","
+        mock_config.return_value.distance_metric = "COSINE"
+        mock_config.return_value.indexing_algorithm = "FLAT"
+
+        vector_store = RedisVectorStore(embeddings=mock_embeddings)
 
         result = vector_store.add_texts(texts=["hello"], keys=["mykey"])
 
         assert result == ["mykey"]
-
-
-def test_add_texts_ids_round_trip_through_delete() -> None:
-    """Ids returned by `add_texts` must delete the documents that were just
-    added, not silently miss because of a double-prefixed key.
-    """
-    with (
-        patch("langchain_redis.vectorstores.RedisConfig") as mock_config,
-        patch("langchain_redis.vectorstores.SearchIndex") as mock_search_index_class,
-    ):
-        mock_index = MagicMock()
-        mock_index.load.return_value = ["myprefix:mykey"]
-        mock_index.drop_keys.return_value = 1
-        vector_store = _make_vector_store(
-            mock_config, mock_search_index_class, mock_index
-        )
-
-        returned_ids = vector_store.add_texts(texts=["hello"], keys=["mykey"])
-        vector_store.delete(ids=returned_ids)
-
-        # The key torn down must match the key that was actually written.
-        mock_index.drop_keys.assert_called_once_with(["myprefix:mykey"])
-
-
-def test_add_texts_strips_prefix_for_auto_generated_keys_too() -> None:
-    """The same stripping applies when no explicit `keys`/`ids` are given and
-    RedisVL auto-generates the key.
-    """
-    with (
-        patch("langchain_redis.vectorstores.RedisConfig") as mock_config,
-        patch("langchain_redis.vectorstores.SearchIndex") as mock_search_index_class,
-    ):
-        mock_index = MagicMock()
-        mock_index.load.return_value = ["myprefix:01ABCXYZ"]
-        vector_store = _make_vector_store(
-            mock_config, mock_search_index_class, mock_index
-        )
-
-        result = vector_store.add_texts(texts=["hello"])
-
-        assert result == ["01ABCXYZ"]

--- a/libs/redis/tests/unit_tests/test_add_texts_ids.py
+++ b/libs/redis/tests/unit_tests/test_add_texts_ids.py
@@ -118,3 +118,97 @@ def test_add_texts_with_both_keys_and_ids() -> None:
         args, kwargs = mock_index.load.call_args
         assert kwargs["keys"] == expected_keys
         assert len(result) == 2
+
+
+def _make_vector_store(
+    mock_config: MagicMock,
+    mock_search_index_class: MagicMock,
+    mock_index: MagicMock,
+) -> RedisVectorStore:
+    mock_embeddings = MagicMock()
+    mock_embeddings.embed_query.return_value = [0.1, 0.2, 0.3]
+    mock_embeddings.embed_documents.return_value = [[0.1, 0.2, 0.3]]
+
+    mock_index.schema.fields.values.return_value = []
+    mock_search_index_class.return_value = mock_index
+    mock_search_index_class.from_dict.return_value = mock_index
+
+    mock_config.return_value.index_name = "test_index"
+    mock_config.return_value.key_prefix = "myprefix"
+    mock_config.return_value.embedding_dimensions = 3
+    mock_config.return_value.content_field = "text"
+    mock_config.return_value.embedding_field = "embedding"
+    mock_config.return_value.redis.return_value = MagicMock()
+    mock_config.return_value.index_schema = None
+    mock_config.return_value.schema_path = None
+    mock_config.return_value.from_existing = False
+    mock_config.return_value.storage_type = "JSON"
+    mock_config.return_value.metadata_schema = None
+    mock_config.return_value.vector_datatype = "FLOAT32"
+    mock_config.return_value.default_tag_separator = ","
+    mock_config.return_value.distance_metric = "COSINE"
+    mock_config.return_value.indexing_algorithm = "FLAT"
+
+    return RedisVectorStore(embeddings=mock_embeddings)
+
+
+def test_add_texts_returns_bare_ids_not_prefixed_redis_keys() -> None:
+    """`SearchIndex.load` hands back the full Redis key it wrote (prefix
+    included), but `add_texts` should return the same bare-id format that
+    `delete()` and `get_by_ids()` expect, so callers can round-trip the ids
+    it returns straight back into either method.
+    """
+    with (
+        patch("langchain_redis.vectorstores.RedisConfig") as mock_config,
+        patch("langchain_redis.vectorstores.SearchIndex") as mock_search_index_class,
+    ):
+        mock_index = MagicMock()
+        mock_index.load.return_value = ["myprefix:mykey"]
+        vector_store = _make_vector_store(
+            mock_config, mock_search_index_class, mock_index
+        )
+
+        result = vector_store.add_texts(texts=["hello"], keys=["mykey"])
+
+        assert result == ["mykey"]
+
+
+def test_add_texts_ids_round_trip_through_delete() -> None:
+    """Ids returned by `add_texts` must delete the documents that were just
+    added, not silently miss because of a double-prefixed key.
+    """
+    with (
+        patch("langchain_redis.vectorstores.RedisConfig") as mock_config,
+        patch("langchain_redis.vectorstores.SearchIndex") as mock_search_index_class,
+    ):
+        mock_index = MagicMock()
+        mock_index.load.return_value = ["myprefix:mykey"]
+        mock_index.drop_keys.return_value = 1
+        vector_store = _make_vector_store(
+            mock_config, mock_search_index_class, mock_index
+        )
+
+        returned_ids = vector_store.add_texts(texts=["hello"], keys=["mykey"])
+        vector_store.delete(ids=returned_ids)
+
+        # The key torn down must match the key that was actually written.
+        mock_index.drop_keys.assert_called_once_with(["myprefix:mykey"])
+
+
+def test_add_texts_strips_prefix_for_auto_generated_keys_too() -> None:
+    """The same stripping applies when no explicit `keys`/`ids` are given and
+    RedisVL auto-generates the key.
+    """
+    with (
+        patch("langchain_redis.vectorstores.RedisConfig") as mock_config,
+        patch("langchain_redis.vectorstores.SearchIndex") as mock_search_index_class,
+    ):
+        mock_index = MagicMock()
+        mock_index.load.return_value = ["myprefix:01ABCXYZ"]
+        vector_store = _make_vector_store(
+            mock_config, mock_search_index_class, mock_index
+        )
+
+        result = vector_store.add_texts(texts=["hello"])
+
+        assert result == ["01ABCXYZ"]


### PR DESCRIPTION
## Summary

`add_texts()` (and `add_documents()` / `from_texts()`) returns whatever `SearchIndex.load()` hands back, which is the full Redis key it just wrote — `key_prefix` included. `delete()` and `get_by_ids()` on the other hand take bare ids and add that same prefix themselves.

So doing the natural thing:

```python
ids = vector_store.add_texts(["hello"], keys=["mykey"])
vector_store.delete(ids=ids)
```

builds `"myprefix:myprefix:mykey"` on the delete side, which doesn't exist, and the delete is a silent no-op. Same happens with `get_by_ids()`, and with auto-generated ids (no `keys`/`ids` passed to `add_texts`).

`get_by_ids()` already returns `Document.id` in bare form, and its own docstring (and `delete()`'s) describes the prefix as something added internally on top of a bare id, so `add_texts()` was the odd one out.

Filed as #179.

## Fix

Strip the known `key_prefix:` back off the keys `SearchIndex.load()` returns before handing them back from `add_texts()`, so what it returns lines up with what `delete()`/`get_by_ids()` expect. This covers both the explicit `keys`/`ids` path and the auto-generated-key path, since both go through the same return statement.

## Test plan

- [x] Added unit tests in `tests/unit_tests/test_add_texts_ids.py` covering: explicit keys getting the prefix stripped, an end-to-end `add_texts` -> `delete` round trip asserting the exact key torn down matches the one written, and the auto-generated-key case.
- [x] `poetry run pytest tests/unit_tests/` (72 passed)
- [x] `poetry run ruff check .` / `ruff format . --diff` / `ruff check . --select I`
- [x] `poetry run mypy .`