### PR TITLE
docs: add missing Generation import in RedisCache README example

### DIFF
--- a/libs/redis/README.md
+++ b/libs/redis/README.md
@@ -158,6 +158,7 @@ The `RedisCache`, `RedisSemanticCache`, and `LangCacheSemanticCache` classes pro
 from langchain_redis import RedisCache, RedisSemanticCache, LangCacheSemanticCache
 from langchain_core.language_models import LLM
 from langchain_core.embeddings import Embeddings
+from langchain_core.outputs import Generation
 
 # Standard cache
 cache = RedisCache(redis_url="redis://localhost:6379", ttl=3600)


### PR DESCRIPTION
## What
The Cache usage example in libs/redis/README.md calls
`Generation(text="cached_response")` but never imports `Generation`,
so copying the snippet as written raises NameError.

## Why
`langchain_core.outputs.Generation` is the correct import — it's
already used this way consistently in cache.py's own docstring
examples (e.g. RedisCache.update). The README example was just
missing the import line.

## Type of change
- [x] Documentation fix (broken code example)

1-line, docs-only change, no functional impact.