### PR TITLE
docs: add missing RedisVectorStore import in RedisConfig class docstring

### DIFF
--- a/libs/redis/langchain_redis/config.py
+++ b/libs/redis/langchain_redis/config.py
@@ -63,7 +63,7 @@ class RedisConfig(BaseModel):
 
     Example:
         ```python
-        from langchain_redis import RedisConfig
+        from langchain_redis import RedisConfig, RedisVectorStore
 
         config = RedisConfig(
             index_name="my_index",


### PR DESCRIPTION
## What
The class-level Example block in RedisConfig's docstring imports
only RedisConfig, but its last line instantiates
`RedisVectorStore(embeddings=my_embeddings, config=config)`, so
copying the example as written raises NameError.

## Why
The example already imports RedisConfig explicitly, showing it's
meant to be self-contained — RedisVectorStore was just missing
from that same import line.

## Type of change
- [x] Documentation fix (broken docstring example)

1-line, docs-only change, no functional impact.