### PR TITLE
fix: AIMessage.tool_calls lost when stored in and retrieved from Redis

### DIFF
--- a/libs/redis/langchain_redis/chat_message_history.py
+++ b/libs/redis/langchain_redis/chat_message_history.py
@@ -4,7 +4,12 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from langchain_core.chat_history import BaseChatMessageHistory
-from langchain_core.messages import BaseMessage, ToolMessage, messages_from_dict
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    ToolMessage,
+    messages_from_dict,
+)
 from redis import Redis
 from redis.exceptions import ConnectionError, ResponseError
 from redisvl.exceptions import RedisSearchError  # type: ignore
@@ -350,6 +355,15 @@ class RedisChatMessageHistory(BaseChatMessageHistory):
         if isinstance(message, ToolMessage):
             common_data_to_store["data"]["tool_call_id"] = message.tool_call_id
             common_data_to_store["data"]["status"] = message.status
+        elif isinstance(message, AIMessage):
+            # Preserve tool_calls / invalid_tool_calls so that an AIMessage
+            # requesting tool use round-trips correctly. Without this, agent
+            # conversations reloaded from Redis lose all tool_calls, since
+            # AIMessage.tool_calls lives outside `additional_kwargs`.
+            common_data_to_store["data"]["tool_calls"] = message.tool_calls
+            common_data_to_store["data"]["invalid_tool_calls"] = (
+                message.invalid_tool_calls
+            )
 
         return common_data_to_store, self._message_key(message_id)
 

--- a/libs/redis/langchain_redis/config.py
+++ b/libs/redis/langchain_redis/config.py
@@ -63,7 +63,7 @@ class RedisConfig(BaseModel):
 
     Example:
         ```python
-        from langchain_redis import RedisConfig
+        from langchain_redis import RedisConfig, RedisVectorStore
 
         config = RedisConfig(
             index_name="my_index",

--- a/libs/redis/tests/unit_tests/test_ai_message_tool_calls.py
+++ b/libs/redis/tests/unit_tests/test_ai_message_tool_calls.py
@@ -1,0 +1,188 @@
+"""Tests for AIMessage.tool_calls being lost on Redis round-trip.
+
+Mirrors the structure of test_tool_message_issue_51.py, which covers the
+sibling case of ToolMessage.tool_call_id / status not surviving a round-trip.
+Here, an AIMessage's tool_calls (and invalid_tool_calls) were not being
+stored at all, so any agent conversation persisted to Redis and then
+reloaded would silently lose which tools the model had asked to call.
+"""
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from langchain_redis import RedisChatMessageHistory
+
+
+class TestAIMessageToolCalls:
+    """Test that AIMessage.tool_calls survive storage and retrieval."""
+
+    @patch("langchain_redis.chat_message_history.SearchIndex")
+    def test_add_ai_message_with_tool_calls_stores_tool_calls(
+        self, mock_search_index: MagicMock
+    ) -> None:
+        """Adding an AIMessage with tool_calls must store them."""
+        mock_redis_client = MagicMock()
+        mock_redis_client.client_setinfo = MagicMock()
+        mock_index_instance = MagicMock()
+        mock_search_index.from_dict.return_value = mock_index_instance
+
+        history = RedisChatMessageHistory(
+            session_id="test_session",
+            redis_client=mock_redis_client,
+        )
+
+        tool_calls = [
+            {
+                "name": "get_weather",
+                "args": {"city": "San Francisco"},
+                "id": "call_123",
+                "type": "tool_call",
+            }
+        ]
+        ai_message = AIMessage(content="", tool_calls=tool_calls)
+        history.add_message(ai_message)
+
+        call_args = mock_index_instance.load.call_args
+        data = call_args[1]["data"][0]
+
+        assert "tool_calls" in data["data"], "tool_calls must be stored"
+        assert data["data"]["tool_calls"] == tool_calls
+        assert "invalid_tool_calls" in data["data"]
+        assert data["data"]["invalid_tool_calls"] == []
+
+    @patch("langchain_redis.chat_message_history.SearchIndex")
+    def test_round_trip_ai_message_preserves_tool_calls(
+        self, mock_search_index: MagicMock
+    ) -> None:
+        """Full round-trip: add an AIMessage with tool_calls, then retrieve it.
+
+        Before this fix, tool_calls was reconstructed as an empty list,
+        even though the original AIMessage had tool_calls set.
+        """
+        mock_redis_client = MagicMock()
+        mock_redis_client.client_setinfo = MagicMock()
+        mock_index_instance = MagicMock()
+        mock_search_index.from_dict.return_value = mock_index_instance
+
+        stored_data = []
+
+        def capture_load(**kwargs: Any) -> None:
+            stored_data.append(kwargs["data"][0])
+
+        mock_index_instance.load.side_effect = capture_load
+
+        history = RedisChatMessageHistory(
+            session_id="test_session",
+            redis_client=mock_redis_client,
+        )
+
+        tool_calls = [
+            {
+                "name": "search",
+                "args": {"query": "python tutorials"},
+                "id": "call_456",
+                "type": "tool_call",
+            }
+        ]
+        ai_message = AIMessage(content="Let me search for that", tool_calls=tool_calls)
+        history.add_message(ai_message)
+
+        assert len(stored_data) == 1
+        stored = stored_data[0]
+
+        mock_index_instance.query.return_value = [
+            {"type": stored["type"], "$.data": json.dumps(stored["data"])}
+        ]
+
+        messages = history.messages
+
+        assert len(messages) == 1
+        assert isinstance(messages[0], AIMessage)
+        assert messages[0].content == "Let me search for that"
+        assert messages[0].tool_calls == tool_calls
+
+    @patch("langchain_redis.chat_message_history.SearchIndex")
+    def test_ai_message_without_tool_calls_round_trips_with_empty_list(
+        self, mock_search_index: MagicMock
+    ) -> None:
+        """A plain AIMessage (no tool calls) should round-trip with tool_calls=[]."""
+        mock_redis_client = MagicMock()
+        mock_redis_client.client_setinfo = MagicMock()
+        mock_index_instance = MagicMock()
+        mock_search_index.from_dict.return_value = mock_index_instance
+
+        stored_data = []
+
+        def capture_load(**kwargs: Any) -> None:
+            stored_data.append(kwargs["data"][0])
+
+        mock_index_instance.load.side_effect = capture_load
+
+        history = RedisChatMessageHistory(
+            session_id="test_session",
+            redis_client=mock_redis_client,
+        )
+
+        history.add_message(AIMessage(content="Hi there"))
+
+        stored = stored_data[0]
+        mock_index_instance.query.return_value = [
+            {"type": stored["type"], "$.data": json.dumps(stored["data"])}
+        ]
+
+        messages = history.messages
+        assert isinstance(messages[0], AIMessage)
+        assert messages[0].tool_calls == []
+
+    @patch("langchain_redis.chat_message_history.SearchIndex")
+    def test_full_tool_calling_conversation_round_trip(
+        self, mock_search_index: MagicMock
+    ) -> None:
+        """End-to-end: Human -> AI (with tool_calls) -> Tool result round-trips."""
+        mock_redis_client = MagicMock()
+        mock_redis_client.client_setinfo = MagicMock()
+        mock_index_instance = MagicMock()
+        mock_search_index.from_dict.return_value = mock_index_instance
+
+        stored_messages = []
+
+        def capture_load(**kwargs: Any) -> None:
+            stored_messages.append(kwargs["data"][0])
+
+        mock_index_instance.load.side_effect = capture_load
+
+        history = RedisChatMessageHistory(
+            session_id="test_session",
+            redis_client=mock_redis_client,
+        )
+
+        tool_calls = [
+            {
+                "name": "get_weather",
+                "args": {"city": "SF"},
+                "id": "call_789",
+                "type": "tool_call",
+            }
+        ]
+        history.add_message(HumanMessage(content="What's the weather in SF?"))
+        history.add_message(AIMessage(content="", tool_calls=tool_calls))
+        history.add_message(
+            ToolMessage(content="Sunny, 72F", tool_call_id="call_789", status="success")
+        )
+
+        mock_index_instance.query.return_value = [
+            {"type": msg["type"], "$.data": json.dumps(msg["data"])}
+            for msg in stored_messages
+        ]
+
+        messages = history.messages
+
+        assert len(messages) == 3
+        assert isinstance(messages[0], HumanMessage)
+        assert isinstance(messages[1], AIMessage)
+        assert messages[1].tool_calls == tool_calls
+        assert isinstance(messages[2], ToolMessage)
+        assert messages[2].tool_call_id == "call_789"


### PR DESCRIPTION
## What
`RedisChatMessageHistory._build_message_entry()` never stored
`AIMessage.tool_calls` / `invalid_tool_calls`, so any AIMessage
requesting tool use silently lost its tool_calls when reloaded from
Redis (`messages` property returns `tool_calls=[]`).

## Why
`AIMessage.tool_calls` is a top-level field, not part of
`additional_kwargs`, so the existing serialization logic dropped it.
This breaks any agent using `RedisChatMessageHistory` for cross-session
conversation memory when the agent uses tools — a core use case for
this library (Human → AI-with-tool-calls → Tool round-trips lose the
AI's tool_calls entirely).

Same root cause and same fix shape as the earlier ToolMessage.tool_call_id
gap (#51) — this covers the AIMessage side, which was missed.

## Testing
- Added `tests/unit_tests/test_ai_message_tool_calls.py` (4 tests):
  storing tool_calls, full round-trip, AIMessage without tool_calls,
  and a full Human/AI/Tool conversation round-trip.
- Full existing unit suite still passes (73 tests; 1 unrelated
  pre-existing failure due to a missing optional dependency in a
  different test file).
- `ruff check` / `ruff format --check` / `mypy` all clean.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)