### PR TITLE
fix: broken embeddings usage in README Vector Store and Cache examples

### DIFF
--- a/libs/redis/README.md
+++ b/libs/redis/README.md
@@ -103,9 +103,9 @@ The `RedisVectorStore` class provides a vector database implementation using Red
 
 ```python
 from langchain_redis import RedisVectorStore, RedisConfig
-from langchain_core.embeddings import Embeddings
+from langchain_openai import OpenAIEmbeddings
 
-embeddings = Embeddings()  # Your preferred embedding model
+embeddings = OpenAIEmbeddings()  # Or your preferred embedding model
 
 config = RedisConfig(
     index_name="my_vectors",
@@ -157,17 +157,17 @@ The `RedisCache`, `RedisSemanticCache`, and `LangCacheSemanticCache` classes pro
 ```python
 from langchain_redis import RedisCache, RedisSemanticCache, LangCacheSemanticCache
 from langchain_core.language_models import LLM
-from langchain_core.embeddings import Embeddings
+from langchain_openai import OpenAIEmbeddings
 from langchain_core.outputs import Generation
 
 # Standard cache
 cache = RedisCache(redis_url="redis://localhost:6379", ttl=3600)
 
 # Semantic cache
-embeddings = Embeddings()  # Your preferred embedding model
+embeddings = OpenAIEmbeddings()  # Or your preferred embedding model
 semantic_cache = RedisSemanticCache(
     redis_url="redis://localhost:6379",
-    embedding=embeddings,
+    embeddings=embeddings,
     distance_threshold=0.1
 )
 


### PR DESCRIPTION
## What
Fixes two bugs in the README's "Usage" examples:
1. `Embeddings()` (abstract base class) → `OpenAIEmbeddings()`, matching
   every other example in this repo.
2. `RedisSemanticCache(..., embedding=embeddings, ...)` → `embeddings=embeddings`
   (the real, correct parameter name).

## Why
Both raise TypeError if copy-pasted as-is:
- `TypeError: Can't instantiate abstract class Embeddings without an
  implementation for abstract methods 'embed_documents', 'embed_query'`
- `TypeError: RedisSemanticCache.__init__() got an unexpected keyword
  argument 'embedding'`

Verified both directly (abstract-class instantiation attempt, and
`inspect.signature(RedisSemanticCache.__init__)` plus reproducing the
actual call). These are the first code blocks in the README's Usage
sections, so any new user following along hits an error immediately.

## Type of change
- [x] Fix typo/bug/link/formatting

Diff size: 1 file changed, 5 insertions(+), 5 deletions(-)